### PR TITLE
fix: improve legacy Cast receiver compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ changing your configuration, and the firewall and portal settings to check.
 Preferences (resolution cap, framerate, bitrate, codec and encoder) are under
 the ⚙ menu entry or
 `gnome-extensions prefs gnome-shell-cast@oxygenws.com`. Leave the codec on
-*Automatic* normally; force VP8 if a receiver freezes or shows a broken picture.
+*Automatic* normally.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,10 @@ changing your configuration, and the firewall and portal settings to check.
    Audio-only devices (speakers, cast groups) show a single **Cast audio** action instead.
 4. To end, click the icon and choose **Stop casting**.
 
-Preferences (resolution cap, framerate, bitrate) are under the ⚙ menu entry or `gnome-extensions prefs gnome-shell-cast@oxygenws.com`.
+Preferences (resolution cap, framerate, bitrate, codec and encoder) are under
+the ⚙ menu entry or
+`gnome-extensions prefs gnome-shell-cast@oxygenws.com`. Leave the codec on
+*Automatic* normally; force VP8 if a receiver freezes or shows a broken picture.
 
 ## Troubleshooting
 

--- a/daemon/src/cast.rs
+++ b/daemon/src/cast.rs
@@ -1,19 +1,57 @@
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr, TcpStream};
+use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Duration;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use log::{debug, info, warn};
-use rust_cast::channels::heartbeat::HeartbeatResponse;
+use rust_cast::ChannelMessage;
+use rust_cast::channels::connection::ConnectionChannel;
+use rust_cast::channels::heartbeat::{HeartbeatChannel, HeartbeatResponse};
+use rust_cast::channels::media::MediaChannel;
 use rust_cast::channels::media::{Media, Metadata, MusicTrackMediaMetadata, StreamType};
-use rust_cast::channels::receiver::CastDeviceApp;
-use rust_cast::{CastDevice, ChannelMessage};
+use rust_cast::channels::receiver::{CastDeviceApp, ReceiverChannel};
+use rust_cast::errors::Error as CastError;
+use rust_cast::message_manager::MessageManager;
+use rustls::{ClientConnection, StreamOwned};
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
 
+use crate::tls;
+
 const DESTINATION_ID: &str = "receiver-0";
+
+type CastStream = StreamOwned<ClientConnection, TcpStream>;
+type CastManager = MessageManager<CastStream>;
+
+struct CastDeviceCompat {
+    manager: Rc<CastManager>,
+    connection: ConnectionChannel<'static, CastStream>,
+    heartbeat: HeartbeatChannel<'static, CastStream>,
+    media: MediaChannel<'static, CastStream>,
+    receiver: ReceiverChannel<'static, CastStream>,
+}
+
+impl CastDeviceCompat {
+    fn receive(&self) -> Result<ChannelMessage, CastError> {
+        let message = self.manager.receive()?;
+        if self.connection.can_handle(&message) {
+            return Ok(ChannelMessage::Connection(self.connection.parse(&message)?));
+        }
+        if self.heartbeat.can_handle(&message) {
+            return Ok(ChannelMessage::Heartbeat(self.heartbeat.parse(&message)?));
+        }
+        if self.media.can_handle(&message) {
+            return Ok(ChannelMessage::Media(self.media.parse(&message)?));
+        }
+        if self.receiver.can_handle(&message) {
+            return Ok(ChannelMessage::Receiver(self.receiver.parse(&message)?));
+        }
+        Ok(ChannelMessage::Raw(message))
+    }
+}
 
 /// The media to load once the stream is ready: URL and HTTP content type (HLS
 /// playlist for screen casts, a progressive audio type for audio-only casts).
@@ -83,8 +121,7 @@ fn run(
     events: &UnboundedSender<CastEvent>,
 ) -> Result<()> {
     info!("connecting to chromecast at {addr}:{port}");
-    let device = CastDevice::connect_without_host_verification(addr.to_string(), port)
-        .map_err(|e| anyhow!("connecting: {e}"))?;
+    let device = connect(addr, port)?;
 
     device
         .connection
@@ -170,6 +207,25 @@ fn run(
             }
         }
     }
+}
+
+fn connect(addr: IpAddr, port: u16) -> Result<CastDeviceCompat> {
+    let socket_addr = SocketAddr::new(addr, port);
+    let tcp = TcpStream::connect_timeout(&socket_addr, Duration::from_secs(4))
+        .with_context(|| format!("connecting to {socket_addr}"))?;
+    let config = tls::client_config();
+    let server_name = rustls::pki_types::ServerName::try_from(addr.to_string())
+        .context("building TLS server name")?;
+    let connection =
+        ClientConnection::new(Arc::new(config), server_name).context("creating TLS connection")?;
+    let manager = Rc::new(MessageManager::new(StreamOwned::new(connection, tcp)));
+    Ok(CastDeviceCompat {
+        connection: ConnectionChannel::new("sender-0", Rc::clone(&manager)),
+        heartbeat: HeartbeatChannel::new("sender-0", DESTINATION_ID, Rc::clone(&manager)),
+        media: MediaChannel::new("sender-0", Rc::clone(&manager)),
+        receiver: ReceiverChannel::new("sender-0", DESTINATION_ID, Rc::clone(&manager)),
+        manager,
+    })
 }
 
 impl Drop for CastControl {

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -6,6 +6,7 @@ mod net;
 mod pipeline;
 mod session;
 mod streaming;
+mod tls;
 mod volume;
 
 use std::collections::HashMap;

--- a/daemon/src/pipeline.rs
+++ b/daemon/src/pipeline.rs
@@ -8,7 +8,7 @@ use gstreamer::prelude::*;
 use log::{info, warn};
 use zbus::zvariant::OwnedValue;
 
-use crate::streaming::encoder::{self, EncoderPolicy, EncodingPolicy, FormatPolicy};
+use crate::streaming::encoder::{self, EncoderPolicy, EncodingPolicy, FormatPolicy, VideoCodec};
 
 pub const PLAYLIST_NAME: &str = "stream.m3u8";
 
@@ -20,6 +20,8 @@ pub struct StreamSettings {
     pub fps: Option<i32>,
     pub bitrate_kbps: Option<i32>,
     pub audio_bitrate_kbps: Option<i32>,
+    /// A forced Cast Streaming codec; `None` offers every usable codec.
+    pub video_codec: Option<VideoCodec>,
     /// Which encoder and raw format the user will accept; `Auto` by default.
     pub encoding: EncodingPolicy,
 }
@@ -75,6 +77,9 @@ impl StreamSettings {
         }
         if let Some(format) = get_string("video-format") {
             settings.encoding.format = FormatPolicy::parse(&format);
+        }
+        if let Some(codec) = get_string("video-codec") {
+            settings.video_codec = VideoCodec::parse(&codec);
         }
         settings
     }
@@ -437,6 +442,26 @@ mod tests {
         let settings = StreamSettings::from_options(options);
         assert_eq!(settings.fps, Some(60));
         assert_eq!(settings.bitrate_kbps, Some(100));
+    }
+
+    #[test]
+    fn video_codec_option_is_parsed_and_unknown_values_are_automatic() {
+        let mut options = HashMap::new();
+        options.insert(
+            "video-codec".to_owned(),
+            OwnedValue::from(zbus::zvariant::Str::from("vp8")),
+        );
+        assert_eq!(
+            StreamSettings::from_options(options).video_codec,
+            Some(VideoCodec::Vp8)
+        );
+
+        let mut options = HashMap::new();
+        options.insert(
+            "video-codec".to_owned(),
+            OwnedValue::from(zbus::zvariant::Str::from("future-codec")),
+        );
+        assert_eq!(StreamSettings::from_options(options).video_codec, None);
     }
 
     #[test]

--- a/daemon/src/streaming/channel.rs
+++ b/daemon/src/streaming/channel.rs
@@ -12,13 +12,13 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow, bail};
 use log::{debug, info, warn};
-use rust_cast::NoCertificateVerification;
 use rust_cast::message_manager::{CastMessage, CastMessagePayload, MessageManager};
 use rustls::{ClientConnection, StreamOwned};
 use serde_json::{Value, json};
 use tokio::sync::mpsc::UnboundedSender;
 
 use super::openscreen::messages::{self, Answer};
+use crate::tls;
 
 const SENDER_ID: &str = "sender-0";
 const RECEIVER_ID: &str = "receiver-0";
@@ -300,10 +300,7 @@ fn connect_tls(addr: IpAddr, port: u16) -> Result<Manager> {
     tcp.set_read_timeout(Some(READ_TIMEOUT))?;
     tcp.set_nodelay(true)?;
 
-    let config = rustls::ClientConfig::builder()
-        .dangerous()
-        .with_custom_certificate_verifier(Arc::new(NoCertificateVerification))
-        .with_no_client_auth();
+    let config = tls::client_config();
     let server_name = rustls::pki_types::ServerName::try_from(addr.to_string())
         .context("building TLS server name")?;
     let connection =

--- a/daemon/src/streaming/encoder.rs
+++ b/daemon/src/streaming/encoder.rs
@@ -22,6 +22,17 @@ pub enum VideoCodec {
 }
 
 impl VideoCodec {
+    /// Anything unrecognised means automatic codec negotiation.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "vp8" => Some(Self::Vp8),
+            "vp9" => Some(Self::Vp9),
+            "av1" => Some(Self::Av1),
+            "h264" => Some(Self::H264),
+            _ => None,
+        }
+    }
+
     /// The `codecName` string used in the Cast OFFER.
     pub fn codec_name(self) -> &'static str {
         match self {
@@ -539,9 +550,13 @@ pub fn policy_failure_message(policy: EncodingPolicy) -> String {
 /// The codecs we can encode on this host, **hardware-encodable ones first**,
 /// then by efficiency. Used to build the OFFER - we advertise only codecs we
 /// can produce, in the order we prefer to use them.
-pub fn available_video_codecs(policy: EncodingPolicy) -> Vec<VideoCodec> {
+pub fn available_video_codecs(
+    policy: EncodingPolicy,
+    preferred: Option<VideoCodec>,
+) -> Vec<VideoCodec> {
     let mut avail: Vec<(VideoCodec, bool)> = EFFICIENCY_ORDER
         .into_iter()
+        .filter(|codec| preferred.is_none_or(|preferred| *codec == preferred))
         .filter_map(|codec| video_encoder(codec, 4_000_000, 30, policy).map(|(_, hw)| (codec, hw)))
         .collect();
     avail.sort_by_key(|&(codec, hw)| (!hw, efficiency_rank(codec)));
@@ -558,6 +573,16 @@ mod tests {
         assert_eq!(VideoCodec::Vp9.codec_name(), "vp9");
         assert_eq!(VideoCodec::Av1.codec_name(), "av1");
         assert_eq!(VideoCodec::H264.codec_name(), "h264");
+    }
+
+    #[test]
+    fn codec_preference_values_parse() {
+        assert_eq!(VideoCodec::parse("vp8"), Some(VideoCodec::Vp8));
+        assert_eq!(VideoCodec::parse("vp9"), Some(VideoCodec::Vp9));
+        assert_eq!(VideoCodec::parse("h264"), Some(VideoCodec::H264));
+        assert_eq!(VideoCodec::parse("av1"), Some(VideoCodec::Av1));
+        assert_eq!(VideoCodec::parse("auto"), None);
+        assert_eq!(VideoCodec::parse("future-codec"), None);
     }
 
     #[test]

--- a/daemon/src/streaming/mod.rs
+++ b/daemon/src/streaming/mod.rs
@@ -197,20 +197,29 @@ fn offer_codecs(
     if capture.is_none() {
         return Ok(Vec::new());
     }
-    let codecs = encoder::available_video_codecs(settings.encoding);
+    let codecs = encoder::available_video_codecs(settings.encoding, settings.video_codec);
     if !codecs.is_empty() {
         return Ok(codecs);
     }
-    let error = anyhow!(encoder::policy_failure_message(settings.encoding));
+    let error = match settings.video_codec {
+        Some(codec) => anyhow!(
+            "no {} encoder matches the selected encoder and pixel format",
+            codec.codec_name()
+        ),
+        None => anyhow!(encoder::policy_failure_message(settings.encoding)),
+    };
     // A forced setting that rules everything out is reported, not worked
     // around: falling back to HLS would quietly defeat the user's choice.
     // With no forced setting this is just "nothing installed" - still worth
     // trying HLS, which needs only H.264.
-    Err(if settings.encoding == encoder::EncodingPolicy::default() {
-        Outcome::Unavailable(error)
-    } else {
-        Outcome::Finished(Err(error))
-    })
+    Err(
+        if settings.encoding == encoder::EncodingPolicy::default() && settings.video_codec.is_none()
+        {
+            Outcome::Unavailable(error)
+        } else {
+            Outcome::Finished(Err(error))
+        },
+    )
 }
 
 /// Codecs the receiver accepted from our OFFER, for "show details".

--- a/daemon/src/streaming/openscreen/bandwidth.rs
+++ b/daemon/src/streaming/openscreen/bandwidth.rs
@@ -28,11 +28,10 @@ const INCREASE_DENOMINATOR: u64 = 10;
 /// How often the loop may change the encoder bitrate.
 pub const CONTROL_INTERVAL: Duration = Duration::from_millis(500);
 
-/// openscreen's `SenderPacketRouter` sends at most this many packets per
-/// burst, one burst per `BURST_INTERVAL`; together they bound how much of the
-/// window could have been spent transmitting.
-const MAX_PACKETS_PER_BURST: u64 = 64;
-const BURST_INTERVAL: Duration = Duration::from_millis(10);
+/// Open Screen's default 24 Mbit/s burst ceiling, divided into 10 ms bursts
+/// of our 1472-byte maximum UDP payloads.
+pub const MAX_PACKETS_PER_BURST: u64 = 21;
+pub const BURST_INTERVAL: Duration = Duration::from_millis(10);
 
 /// A ring buffer of byte counts over `NUM_TIMESLICES` equal slices.
 struct FlowTracker {
@@ -271,7 +270,7 @@ mod tests {
     fn confirmed_bytes_become_bits_per_second() {
         let now = Instant::now();
         let mut e = BandwidthEstimator::new(now);
-        // 12800 packets is a full window's worth of bursts.
+        // Far more packets than a full window can carry saturates the model.
         for step in 0..20 {
             e.on_burst_sent(12_500, 640, at(now, step * 100));
             e.on_bytes_confirmed(12_500, at(now, step * 100));
@@ -290,7 +289,7 @@ mod tests {
         let now = Instant::now();
         let mut e = BandwidthEstimator::new(now);
         for step in 0..20 {
-            e.on_burst_sent(12_500, 64, at(now, step * 100));
+            e.on_burst_sent(12_500, MAX_PACKETS_PER_BURST, at(now, step * 100));
             e.on_bytes_confirmed(12_500, at(now, step * 100));
         }
         let estimate = e.estimate_bps(at(now, 2000)).unwrap();

--- a/daemon/src/streaming/openscreen/sender.rs
+++ b/daemon/src/streaming/openscreen/sender.rs
@@ -140,6 +140,50 @@ struct SentFrame {
     packets: PacketizedFrame,
 }
 
+/// Spaces RTP into the same bounded 10 ms bursts as Open Screen's
+/// `SenderPacketRouter`. A successful local UDP send does not mean that a
+/// receiver's much smaller input buffer can absorb an entire large keyframe.
+struct PacketPacer {
+    burst_started: Instant,
+    packets_in_burst: u64,
+}
+
+impl PacketPacer {
+    fn new(now: Instant) -> Self {
+        Self {
+            burst_started: now,
+            packets_in_burst: 0,
+        }
+    }
+
+    fn delay_for_next_packet(&mut self, now: Instant) -> Duration {
+        let next_burst = self
+            .burst_started
+            .checked_add(bandwidth::BURST_INTERVAL)
+            .unwrap_or(now);
+        if now >= next_burst {
+            self.burst_started = now;
+            self.packets_in_burst = 1;
+            return Duration::ZERO;
+        }
+        if self.packets_in_burst < bandwidth::MAX_PACKETS_PER_BURST {
+            self.packets_in_burst = self.packets_in_burst.saturating_add(1);
+            return Duration::ZERO;
+        }
+
+        self.burst_started = next_burst;
+        self.packets_in_burst = 1;
+        next_burst.saturating_duration_since(now)
+    }
+
+    fn wait_for_next_packet(&mut self) {
+        let delay = self.delay_for_next_packet(Instant::now());
+        if !delay.is_zero() {
+            thread::sleep(delay);
+        }
+    }
+}
+
 struct Stream {
     kind: StreamKind,
     ssrc: u32,
@@ -258,6 +302,7 @@ fn service_rtcp(
     events: &mut rtcp::ReceiverEvents,
     receive_buffer: &mut [u8; 1500],
     estimator: &mut BandwidthEstimator,
+    pacer: &mut PacketPacer,
     acked: &mut bool,
     request_keyframe: &dyn Fn(),
 ) {
@@ -291,7 +336,7 @@ fn service_rtcp(
                 }
             }
             for nack in &events.nacks {
-                retransmit(socket, peer, stream, nack);
+                retransmit(socket, peer, stream, nack, pacer);
             }
             if events.picture_loss && stream.kind == StreamKind::Video {
                 debug!("receiver reported picture loss, forcing a key frame");
@@ -398,6 +443,7 @@ fn run(
     let mut acked = false;
     let mut reported_silence = false;
     let mut reported_drops = false;
+    let mut pacer = PacketPacer::new(Instant::now());
     let mut rate_state = RateState {
         estimator: BandwidthEstimator::new(Instant::now()),
         current_bps: rate_control.start_bps,
@@ -425,7 +471,7 @@ fn run(
                         video_started_at = Some(Instant::now());
                     }
                     let before = (stream.octet_count, stream.packet_count);
-                    let dropped = send_frame(socket, peer, stream, &chunk);
+                    let dropped = send_frame(socket, peer, stream, &chunk, &mut pacer);
                     rate_state.estimator.on_burst_sent(
                         u64::from(stream.octet_count.wrapping_sub(before.0)),
                         u64::from(stream.packet_count.wrapping_sub(before.1)),
@@ -462,6 +508,7 @@ fn run(
             &mut events,
             &mut receive_buffer,
             &mut rate_state.estimator,
+            &mut pacer,
             &mut acked,
             request_keyframe,
         );
@@ -506,7 +553,13 @@ fn send_sender_report(
 /// the socket is non-blocking (so RTCP can be polled), so a frame's packet
 /// burst hits `WouldBlock`, and a dropped packet costs the receiver the whole
 /// frame. Waiting paces us to what the link accepts. False if it never went.
-fn send_packet(socket: &UdpSocket, peer: SocketAddr, packet: &[u8]) -> bool {
+fn send_packet(
+    socket: &UdpSocket,
+    peer: SocketAddr,
+    packet: &[u8],
+    pacer: &mut PacketPacer,
+) -> bool {
+    pacer.wait_for_next_packet();
     let deadline = Instant::now().checked_add(SEND_TIMEOUT);
     loop {
         match socket.send_to(packet, peer) {
@@ -532,6 +585,7 @@ fn send_frame(
     peer: SocketAddr,
     stream: &mut Stream,
     chunk: &EncodedChunk,
+    pacer: &mut PacketPacer,
 ) -> u32 {
     let frame_id = stream.next_frame_id;
     stream.next_frame_id = stream.next_frame_id.wrapping_add(1);
@@ -558,13 +612,21 @@ fn send_frame(
         .packetizer
         .packetize(&frame, buffer, |payload| cipher.apply_keystream(payload));
 
+    if chunk.kind == StreamKind::Video && chunk.is_key_frame {
+        debug!(
+            "video key frame {frame_id}: {} bytes in {} packets",
+            chunk.data.len(),
+            packets.iter().count()
+        );
+    }
+
     let mut dropped: u32 = 0;
     for packet in packets.iter() {
         stream.packet_count = stream.packet_count.wrapping_add(1);
         stream.octet_count = stream
             .octet_count
             .wrapping_add(u32::try_from(packet.len()).unwrap_or(u32::MAX));
-        if !send_packet(socket, peer, packet) {
+        if !send_packet(socket, peer, packet, pacer) {
             dropped = dropped.saturating_add(1);
         }
     }
@@ -577,7 +639,13 @@ fn send_frame(
     dropped
 }
 
-fn retransmit(socket: &UdpSocket, peer: SocketAddr, stream: &Stream, nack: &rtcp::Nack) {
+fn retransmit(
+    socket: &UdpSocket,
+    peer: SocketAddr,
+    stream: &Stream,
+    nack: &rtcp::Nack,
+    pacer: &mut PacketPacer,
+) {
     let Some(frame) = stream
         .history
         .iter()
@@ -587,10 +655,10 @@ fn retransmit(socket: &UdpSocket, peer: SocketAddr, stream: &Stream, nack: &rtcp
     };
     if nack.packet_id == rtcp::ALL_PACKETS_LOST {
         for packet in frame.packets.iter() {
-            send_packet(socket, peer, packet);
+            send_packet(socket, peer, packet, pacer);
         }
     } else if let Some(packet) = frame.packets.packet(nack.packet_id) {
-        send_packet(socket, peer, packet);
+        send_packet(socket, peer, packet, pacer);
     } else {
         // The receiver NACKed a packet id we never produced; nothing to resend.
     }
@@ -599,6 +667,23 @@ fn retransmit(socket: &UdpSocket, peer: SocketAddr, stream: &Stream, nack: &rtcp
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn packet_pacer_splits_packets_into_ten_millisecond_bursts() {
+        let mut now = Instant::now();
+        let mut pacer = PacketPacer::new(now);
+        for _ in 0..bandwidth::MAX_PACKETS_PER_BURST {
+            assert_eq!(pacer.delay_for_next_packet(now), Duration::ZERO);
+        }
+
+        let delay = pacer.delay_for_next_packet(now);
+        assert_eq!(delay, bandwidth::BURST_INTERVAL);
+        now += delay;
+        for _ in 1..bandwidth::MAX_PACKETS_PER_BURST {
+            assert_eq!(pacer.delay_for_next_packet(now), Duration::ZERO);
+        }
+        assert_eq!(pacer.delay_for_next_packet(now), bandwidth::BURST_INTERVAL);
+    }
 
     #[test]
     fn sender_report_works_on_the_unconnected_rtp_socket() {

--- a/daemon/src/streaming/openscreen/sender.rs
+++ b/daemon/src/streaming/openscreen/sender.rs
@@ -483,12 +483,23 @@ fn run(
                     stream.packet_count,
                     stream.octet_count,
                 );
-                let _ = socket.send(&report);
+                let _ = send_sender_report(socket, peer, &report);
                 stream.last_report = Some(Instant::now());
             }
         }
     }
     info!("mirror sender stopped");
+}
+
+/// Sender reports share the unconnected RTP socket so receiver feedback comes
+/// back to the same port. Unlike RTP's `send_to`, the old `send` call failed
+/// with `ENOTCONN` after the socket was deliberately made unconnected.
+fn send_sender_report(
+    socket: &UdpSocket,
+    peer: SocketAddr,
+    report: &[u8],
+) -> std::io::Result<usize> {
+    socket.send_to(report, peer)
 }
 
 /// Sends one packet, waiting out a full send buffer rather than dropping it:
@@ -588,6 +599,25 @@ fn retransmit(socket: &UdpSocket, peer: SocketAddr, stream: &Stream, nack: &rtcp
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sender_report_works_on_the_unconnected_rtp_socket() {
+        let receiver = UdpSocket::bind("127.0.0.1:0").unwrap();
+        receiver
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+        let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
+        assert!(sender.peer_addr().is_err());
+
+        let report = [0x80, 200, 0, 0];
+        send_sender_report(&sender, receiver.local_addr().unwrap(), &report).unwrap();
+
+        let mut received = [0; 4];
+        let (size, from) = receiver.recv_from(&mut received).unwrap();
+        assert_eq!(size, report.len());
+        assert_eq!(received, report);
+        assert_eq!(from, sender.local_addr().unwrap());
+    }
 
     fn chunk() -> EncodedChunk {
         gstreamer::init().unwrap();

--- a/daemon/src/tls.rs
+++ b/daemon/src/tls.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::crypto::aws_lc_rs::default_provider;
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{ClientConfig, DigitallySignedStruct, SignatureScheme};
+
+/// Builds the deliberately unauthenticated TLS configuration required by the
+/// Cast protocol.
+///
+/// Cast devices use self-signed certificates, and some legacy receivers use
+/// X.509 v1 certificates that rustls cannot parse even for the TLS handshake
+/// signature check. `rust_cast` already accepts any device certificate; this
+/// verifier additionally skips that parsing-dependent check for compatibility.
+pub fn client_config() -> ClientConfig {
+    ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(CastCertificateVerifier))
+        .with_no_client_auth()
+}
+
+#[derive(Debug)]
+struct CastCertificateVerifier;
+
+impl ServerCertVerifier for CastCertificateVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}

--- a/daemon/src/volume.rs
+++ b/daemon/src/volume.rs
@@ -5,9 +5,9 @@ use std::sync::mpsc::{Receiver, Sender, channel};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
+use crate::tls;
 use anyhow::{Context, Result, anyhow};
 use log::{debug, warn};
-use rust_cast::NoCertificateVerification;
 use rust_cast::message_manager::{CastMessage, CastMessagePayload, MessageManager};
 use rustls::{ClientConnection, StreamOwned};
 use serde_json::{Value, json};
@@ -190,10 +190,7 @@ fn connect(addr: IpAddr, port: u16) -> Result<Manager> {
     tcp.set_read_timeout(Some(READ_TIMEOUT))?;
     tcp.set_nodelay(true)?;
 
-    let config = rustls::ClientConfig::builder()
-        .dangerous()
-        .with_custom_certificate_verifier(Arc::new(NoCertificateVerification))
-        .with_no_client_auth();
+    let config = tls::client_config();
     let server_name = rustls::pki_types::ServerName::try_from(addr.to_string())
         .context("building TLS server name")?;
     let connection =

--- a/extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js
+++ b/extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js
@@ -408,6 +408,7 @@ export class CastMenu {
                 this._settings.get_int('audio-bitrate-kbps'),
             ),
             'video-encoder': new GLib.Variant('s', this._settings.get_string('video-encoder')),
+            'video-codec': new GLib.Variant('s', this._settings.get_string('video-codec')),
             'video-format': new GLib.Variant('s', this._settings.get_string('video-format')),
         };
 

--- a/extension/gnome-shell-cast@oxygenws.com/po/ar.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/ar.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-08-21 21:03+0200\n"
+"POT-Creation-Date: 2026-09-02 21:09+0200\n"
 "PO-Revision-Date: 2026-08-14 10:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: Arabic <https://github.com/omid/gnome-shell-cast>\n"
@@ -73,20 +73,20 @@ msgstr "المرمّز: %s (البرمجيات)"
 msgid "Receiver supports: %s"
 msgstr "المستقبِل يدعم: %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:446
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:447
 msgid "The cast failed."
 msgstr "فشل البث."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:453
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
 #, javascript-format
 msgid "The device ended the session (%s)."
 msgstr "أنهى الجهاز الجلسة (%s)."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:455
 msgid "The device ended the session."
 msgstr "أنهى الجهاز الجلسة."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:502
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:503
 #: extension/gnome-shell-cast@oxygenws.com/lib/indicator.js:22
 #: extension/gnome-shell-cast@oxygenws.com/lib/quickIndicator.js:62
 msgid "GNOME Shell Cast"
@@ -139,7 +139,7 @@ msgid "Close"
 msgstr "أغلِق"
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/errorDialog.js:40
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:266
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:283
 msgid "Report an issue"
 msgstr "أبلغ عن مشكلة"
 
@@ -179,7 +179,7 @@ msgid "Copy the command, then paste it into a terminal and run it."
 msgstr "انسخ الأمر ثم الصقه في طرفية ونفّذه."
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/setupDialog.js:43
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:265
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:282
 msgid "Homepage"
 msgstr "الموقع"
 
@@ -191,200 +191,211 @@ msgstr "انسخ الأمر"
 msgid "Copied! Paste it into a terminal and run it."
 msgstr "نُسخ. الصقه في طرفية ونفّذه."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:32
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:33
 msgid ""
 "No VA-API encoder for your graphics card. Install your distribution’s VA-API "
 "driver."
 msgstr "لا يوجد مرمّز VA-API لبطاقة الرسومات. ثبّت مُشغّل VA-API من توزيعتك."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:36
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:37
 msgid "Install the NVIDIA driver and the GStreamer nvcodec plugin."
 msgstr "ثبّت مُشغّل NVIDIA وإضافة nvcodec لـ GStreamer."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:39
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:40
 #, javascript-format
 msgid "The GStreamer VA-API plugin is missing. Install the %s package."
 msgstr "إضافة GStreamer VA-API مفقودة. ثبّت حزمة %s."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:43
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:44
 msgid ""
 "The GStreamer VA-API plugin is missing. Install it from your distribution."
 msgstr "إضافة GStreamer VA-API مفقودة. ثبّتها من توزيعتك."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:62
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:70
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:74
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:81
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:71
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:139
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:146
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:147
 msgid "Automatic"
 msgstr "تلقائي"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
 msgid "Native"
 msgstr "أصلي"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
 msgid "4K (2160p)"
 msgstr "4K (2160p)"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
 msgid "1440p"
 msgstr "1440p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
 msgid "1080p"
 msgstr "1080p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:68
 msgid "720p"
 msgstr "720p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:75
-msgid "Hardware only"
-msgstr "العتاد فقط"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:76
-msgid "Software only"
-msgstr "البرمجيات فقط"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:77
-msgid "VA-API (Intel, AMD)"
-msgstr "VA-API (Intel، AMD)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:78
-msgid "NVENC (NVIDIA)"
-msgstr "NVENC (NVIDIA)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
-msgid "V4L2 (Arm boards)"
-msgstr "V4L2 (لوحات Arm)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:84
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:73
 msgid "Advanced"
 msgstr "متقدم"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:90
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
 msgid "Stream quality"
 msgstr "جودة الدفق"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:91
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:80
 msgid "Applied the next time a cast is started"
 msgstr "يُطبَّق عند بدء البث التالي"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:85
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:15
 msgid "Maximum resolution"
 msgstr "الميز الأقصى"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:86
 msgid "Above 1080p needs a hardware encoder and a matching bitrate"
 msgstr "فوق 1080p يلزم مرمّز عتادي ومعدل بتات مناسب"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
 msgid "Framerate"
 msgstr "معدل الإطارات"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
 msgid "Frames per second"
 msgstr "إطارات في الثانية"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
 msgid "Video bitrate"
 msgstr "معدل بتات الفيديو"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:119
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
 msgid "kbit/s: about 4000 for 720p, 8000 for 1080p, 30000 for 4K"
 msgstr "kbit/s: نحو 4000 لـ 720p، و8000 لـ 1080p، و30000 لـ 4K"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:129
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
 msgid "Audio bitrate"
 msgstr "معدل بتات الصوت"
 
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:140
+msgid "Hardware only"
+msgstr "العتاد فقط"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:141
+msgid "Software only"
+msgstr "البرمجيات فقط"
+
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:142
+msgid "VA-API (Intel, AMD)"
+msgstr "VA-API (Intel، AMD)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+msgid "NVENC (NVIDIA)"
+msgstr "NVENC (NVIDIA)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:144
+msgid "V4L2 (Arm boards)"
+msgstr "V4L2 (لوحات Arm)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
 msgid "Encoding"
 msgstr "الترميز"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:151
 msgid "Casting fails with a message when a forced choice cannot be used"
 msgstr "يفشل البث مع رسالة عندما يتعذّر استخدام خيار مفروض"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:148
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:156
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:46
 msgid "Video encoder"
 msgstr "مرمّز الفيديو"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:158
 msgid ""
 "Automatic prefers your graphics card; choose software if the picture breaks "
 "up"
 msgstr "يفضّل الوضع التلقائي بطاقة الرسوميات؛ اختر البرمجيات إذا تقطّعت الصورة"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:161
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:56
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
+#, fuzzy
+msgid "Video codec"
+msgstr "مرمّز الفيديو"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
+msgid "Choose VP8 if the receiver freezes or displays a broken picture"
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
 msgid "Pixel format"
 msgstr "تنسيق البكسل"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:162
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:181
 msgid "Automatic suits every encoder; only change this to work around a driver"
 msgstr "الوضع التلقائي يناسب كل المرمّزات؛ لا تغيّره إلا لتجاوز مشكلة في المشغّل"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:191
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
 msgid "Hardware encoding is unavailable"
 msgstr "الترميز العتادي غير متوفّر"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:204
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:224
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:221
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:241
 msgid "Menu"
 msgstr "قائمة"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:61
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:225
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:73
 msgid "Show cast details"
 msgstr "أظهر تفاصيل البث"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:209
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:62
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:226
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:74
 msgid "Show the transport and codecs under the active device while casting"
 msgstr "أظهر النقل والمرمّزات أسفل الجهاز النشط أثناء البث"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Top bar"
 msgstr "الشريط العلوي"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Quick settings"
 msgstr "الإعدادات السريعة"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:219
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:236
 msgid "General"
 msgstr "عام"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:228
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:70
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:245
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:82
 msgid "Indicator location"
 msgstr "موضع الأيقونة"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:229
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:246
 msgid "Show the cast icon in the top bar, or in the quick settings menu"
 msgstr "أظهر أيقونة البث في الشريط العلوي أو في قائمة الإعدادات السريعة"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:243
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:260
 msgid "About"
 msgstr "عن"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:254
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:271
 #, javascript-format
 msgid "Version %s"
 msgstr "الإصدارة %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:269
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:286
 msgid "Help"
 msgstr "مساعدة"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:270
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:287
 msgid "Common problems and their fixes"
 msgstr "المشكلات الشائعة وحلولها"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:273
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:290
 msgid "Troubleshooting guide"
 msgstr "دليل حل المشكلات"
 
@@ -441,7 +452,14 @@ msgstr ""
 "تثبّت «vaapi» (Intel، AMD) و«nvenc» (NVIDIA) و«v4l2» (لوحات Arm) واجهة عتاد "
 "واحدة؛ يفشل البث مع رسالة إذا تعذّر تحقيق الخيار."
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:57
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid ""
+"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
+"available on this computer and lets the receiver choose. Force VP8 when a "
+"receiver freezes or displays a broken picture with another codec."
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""
 "The raw video format handed to the encoder. \"auto\" offers both and lets "
 "negotiation pick whichever the chosen encoder accepts. Forcing a format "
@@ -452,7 +470,7 @@ msgstr ""
 "اختيار ما يقبله المرمّز المحدد. فرض تنسيق يقصر البث على المرمّزات التي تقبله، "
 "وهو ما يعني على معظم الأنظمة فرض نوع المرمّز أيضًا."
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:71
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:83
 msgid ""
 "Where to show the cast indicator: the top-bar tray, or the quick settings "
 "menu."

--- a/extension/gnome-shell-cast@oxygenws.com/po/ar.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/ar.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-09-02 21:09+0200\n"
+"POT-Creation-Date: 2026-09-03 08:40+0200\n"
 "PO-Revision-Date: 2026-08-14 10:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: Arabic <https://github.com/omid/gnome-shell-cast>\n"
@@ -321,13 +321,13 @@ msgstr "يفضّل الوضع التلقائي بطاقة الرسوميات؛ �
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
-#, fuzzy
 msgid "Video codec"
-msgstr "مرمّز الفيديو"
+msgstr "برنامج ترميز الفيديو"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
-msgid "Choose VP8 if the receiver freezes or displays a broken picture"
-msgstr ""
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid "Automatic lets the receiver choose from the available codecs"
+msgstr "يتيح الوضع التلقائي للمستقبِل الاختيار من برامج الترميز المتاحة"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
@@ -451,13 +451,6 @@ msgstr ""
 "البرمجيات. اختر البرمجيات عندما ينتج مشغّل الرسوميات صورة معطوبة أو متقطّعة. "
 "تثبّت «vaapi» (Intel، AMD) و«nvenc» (NVIDIA) و«v4l2» (لوحات Arm) واجهة عتاد "
 "واحدة؛ يفشل البث مع رسالة إذا تعذّر تحقيق الخيار."
-
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
-msgid ""
-"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
-"available on this computer and lets the receiver choose. Force VP8 when a "
-"receiver freezes or displays a broken picture with another codec."
-msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""

--- a/extension/gnome-shell-cast@oxygenws.com/po/bg.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/bg.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-08-21 21:03+0200\n"
+"POT-Creation-Date: 2026-09-02 21:09+0200\n"
 "PO-Revision-Date: 2026-08-17 12:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: Bulgarian <https://github.com/omid/gnome-shell-cast>\n"
@@ -72,20 +72,20 @@ msgstr "Кодер: %s (софтуерен)"
 msgid "Receiver supports: %s"
 msgstr "Приемникът поддържа: %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:446
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:447
 msgid "The cast failed."
 msgstr "Предаването е неуспешно."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:453
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
 #, javascript-format
 msgid "The device ended the session (%s)."
 msgstr "Устройството прекрати сесията (%s)."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:455
 msgid "The device ended the session."
 msgstr "Устройството прекрати сесията."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:502
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:503
 #: extension/gnome-shell-cast@oxygenws.com/lib/indicator.js:22
 #: extension/gnome-shell-cast@oxygenws.com/lib/quickIndicator.js:62
 msgid "GNOME Shell Cast"
@@ -143,7 +143,7 @@ msgid "Close"
 msgstr "Затваряне"
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/errorDialog.js:40
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:266
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:283
 msgid "Report an issue"
 msgstr "Докладване на грешка"
 
@@ -185,7 +185,7 @@ msgid "Copy the command, then paste it into a terminal and run it."
 msgstr "Копирайте командата, поставете я в терминал и я изпълнете."
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/setupDialog.js:43
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:265
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:282
 msgid "Homepage"
 msgstr "Начална страница"
 
@@ -197,7 +197,7 @@ msgstr "Копиране на командата"
 msgid "Copied! Paste it into a terminal and run it."
 msgstr "Копирано! Поставете го в терминал и го изпълнете."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:32
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:33
 msgid ""
 "No VA-API encoder for your graphics card. Install your distribution’s VA-API "
 "driver."
@@ -205,126 +205,127 @@ msgstr ""
 "Няма кодер VA-API за вашата видеокарта. Инсталирайте драйвера VA-API на "
 "дистрибуцията си."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:36
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:37
 msgid "Install the NVIDIA driver and the GStreamer nvcodec plugin."
 msgstr "Инсталирайте драйвера на NVIDIA и приставката nvcodec на GStreamer."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:39
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:40
 #, javascript-format
 msgid "The GStreamer VA-API plugin is missing. Install the %s package."
 msgstr "Липсва приставката VA-API на GStreamer. Инсталирайте пакета %s."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:43
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:44
 msgid ""
 "The GStreamer VA-API plugin is missing. Install it from your distribution."
 msgstr ""
 "Липсва приставката VA-API на GStreamer. Инсталирайте я чрез дистрибуцията си."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:62
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:70
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:74
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:81
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:71
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:139
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:146
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:147
 msgid "Automatic"
 msgstr "Автоматично"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
 msgid "Native"
 msgstr "Присъща"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
 msgid "4K (2160p)"
 msgstr "4K (2160p)"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
 msgid "1440p"
 msgstr "1440p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
 msgid "1080p"
 msgstr "1080p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:68
 msgid "720p"
 msgstr "720p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:75
-msgid "Hardware only"
-msgstr "Само хардуерен"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:76
-msgid "Software only"
-msgstr "Само софтуерен"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:77
-msgid "VA-API (Intel, AMD)"
-msgstr "VA-API (Intel, AMD)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:78
-msgid "NVENC (NVIDIA)"
-msgstr "NVENC (NVIDIA)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
-msgid "V4L2 (Arm boards)"
-msgstr "V4L2 (платки Arm)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:84
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:73
 msgid "Advanced"
 msgstr "Разширени"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:90
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
 msgid "Stream quality"
 msgstr "Качество на предаването"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:91
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:80
 msgid "Applied the next time a cast is started"
 msgstr "Прилага се при следващото стартиране на предаване"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:85
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:15
 msgid "Maximum resolution"
 msgstr "Максимална разделителна способност"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:86
 msgid "Above 1080p needs a hardware encoder and a matching bitrate"
 msgstr ""
 "Над 1080p са необходими хардуерен кодер и съответната скорост на битовете"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
 msgid "Framerate"
 msgstr "Честота на кадрите"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
 msgid "Frames per second"
 msgstr "Кадри в секунда"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
 msgid "Video bitrate"
 msgstr "Скорост на битовете за видеото"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:119
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
 msgid "kbit/s: about 4000 for 720p, 8000 for 1080p, 30000 for 4K"
 msgstr "kbit/s: около 4000 за 720p, 8000 за 1080p, 30000 за 4K"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:129
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
 msgid "Audio bitrate"
 msgstr "Скорост на битовете за аудиото"
 
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:140
+msgid "Hardware only"
+msgstr "Само хардуерен"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:141
+msgid "Software only"
+msgstr "Само софтуерен"
+
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:142
+msgid "VA-API (Intel, AMD)"
+msgstr "VA-API (Intel, AMD)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+msgid "NVENC (NVIDIA)"
+msgstr "NVENC (NVIDIA)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:144
+msgid "V4L2 (Arm boards)"
+msgstr "V4L2 (платки Arm)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
 msgid "Encoding"
 msgstr "Кодиране"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:151
 msgid "Casting fails with a message when a forced choice cannot be used"
 msgstr ""
 "Предаването се проваля със съобщение, когато зададеният избор не може да се "
 "използва"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:148
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:156
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:46
 msgid "Video encoder"
 msgstr "Видео кодер"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:158
 msgid ""
 "Automatic prefers your graphics card; choose software if the picture breaks "
 "up"
@@ -332,79 +333,89 @@ msgstr ""
 "Автоматично предпочита видеокартата; изберете софтуерен, ако картината се "
 "накъсва"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:161
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:56
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
+#, fuzzy
+msgid "Video codec"
+msgstr "Видео кодер"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
+msgid "Choose VP8 if the receiver freezes or displays a broken picture"
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
 msgid "Pixel format"
 msgstr "Формат на пикселите"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:162
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:181
 msgid "Automatic suits every encoder; only change this to work around a driver"
 msgstr ""
 "Автоматично е подходящо за всеки кодер; променяйте само за да заобиколите "
 "драйвер"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:191
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
 msgid "Hardware encoding is unavailable"
 msgstr "Хардуерното кодиране не е налично"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:204
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:224
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:221
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:241
 msgid "Menu"
 msgstr "Меню"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:61
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:225
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:73
 msgid "Show cast details"
 msgstr "Показване на подробности за предаването"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:209
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:62
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:226
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:74
 msgid "Show the transport and codecs under the active device while casting"
 msgstr ""
 "Показване на транспорта и кодеците под активното устройство по време на "
 "предаване"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Top bar"
 msgstr "Горна лента"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Quick settings"
 msgstr "Бързи настройки"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:219
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:236
 msgid "General"
 msgstr "Общи"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:228
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:70
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:245
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:82
 msgid "Indicator location"
 msgstr "Местоположение на индикатора"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:229
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:246
 msgid "Show the cast icon in the top bar, or in the quick settings menu"
 msgstr ""
 "Показване на иконата за предаване в горната лента или в менюто за бързи "
 "настройки"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:243
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:260
 msgid "About"
 msgstr "Относно"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:254
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:271
 #, javascript-format
 msgid "Version %s"
 msgstr "Версия %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:269
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:286
 msgid "Help"
 msgstr "Помощ"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:270
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:287
 msgid "Common problems and their fixes"
 msgstr "Често срещани проблеми и решенията им"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:273
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:290
 msgid "Troubleshooting guide"
 msgstr "Ръководство за справяне с проблеми"
 
@@ -465,7 +476,14 @@ msgstr ""
 "„v4l2“ (платки Arm) задават един хардуерен интерфейс; предаването се проваля "
 "със съобщение, ако изборът не може да бъде изпълнен."
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:57
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid ""
+"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
+"available on this computer and lets the receiver choose. Force VP8 when a "
+"receiver freezes or displays a broken picture with another codec."
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""
 "The raw video format handed to the encoder. \"auto\" offers both and lets "
 "negotiation pick whichever the chosen encoder accepts. Forcing a format "
@@ -477,7 +495,7 @@ msgstr ""
 "на формат ограничава предаването до кодерите, които го приемат, което на "
 "повечето системи означава да се наложи и видът на кодера."
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:71
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:83
 msgid ""
 "Where to show the cast indicator: the top-bar tray, or the quick settings "
 "menu."

--- a/extension/gnome-shell-cast@oxygenws.com/po/bg.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/bg.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-09-02 21:09+0200\n"
+"POT-Creation-Date: 2026-09-03 08:40+0200\n"
 "PO-Revision-Date: 2026-08-17 12:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: Bulgarian <https://github.com/omid/gnome-shell-cast>\n"
@@ -335,13 +335,13 @@ msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
-#, fuzzy
 msgid "Video codec"
-msgstr "Видео кодер"
+msgstr "Видео кодек"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
-msgid "Choose VP8 if the receiver freezes or displays a broken picture"
-msgstr ""
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid "Automatic lets the receiver choose from the available codecs"
+msgstr "Автоматичният режим позволява на приемника да избере от наличните кодеци"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
@@ -475,13 +475,6 @@ msgstr ""
 "развалена или накъсана картина. „vaapi“ (Intel, AMD), „nvenc“ (NVIDIA) и "
 "„v4l2“ (платки Arm) задават един хардуерен интерфейс; предаването се проваля "
 "със съобщение, ако изборът не може да бъде изпълнен."
-
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
-msgid ""
-"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
-"available on this computer and lets the receiver choose. Force VP8 when a "
-"receiver freezes or displays a broken picture with another codec."
-msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""

--- a/extension/gnome-shell-cast@oxygenws.com/po/bn.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/bn.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-08-21 21:03+0200\n"
+"POT-Creation-Date: 2026-09-02 21:09+0200\n"
 "PO-Revision-Date: 2026-08-14 10:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: Bengali <https://github.com/omid/gnome-shell-cast>\n"
@@ -72,20 +72,20 @@ msgstr "এনকোডার: %s (সফটওয়্যার)"
 msgid "Receiver supports: %s"
 msgstr "রিসিভার সমর্থন করে: %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:446
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:447
 msgid "The cast failed."
 msgstr "কাস্ট ব্যর্থ হয়েছে।"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:453
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
 #, javascript-format
 msgid "The device ended the session (%s)."
 msgstr "ডিভাইসটি সেশন শেষ করেছে (%s)।"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:455
 msgid "The device ended the session."
 msgstr "ডিভাইসটি সেশন শেষ করেছে।"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:502
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:503
 #: extension/gnome-shell-cast@oxygenws.com/lib/indicator.js:22
 #: extension/gnome-shell-cast@oxygenws.com/lib/quickIndicator.js:62
 msgid "GNOME Shell Cast"
@@ -141,7 +141,7 @@ msgid "Close"
 msgstr "বন্ধ করুন"
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/errorDialog.js:40
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:266
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:283
 msgid "Report an issue"
 msgstr "সমস্যা রিপোর্ট করুন"
 
@@ -182,7 +182,7 @@ msgid "Copy the command, then paste it into a terminal and run it."
 msgstr "কমান্ডটি অনুলিপি করুন, তারপর টার্মিনালে পেস্ট করে চালান।"
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/setupDialog.js:43
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:265
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:282
 msgid "Homepage"
 msgstr "ওয়েবসাইট"
 
@@ -194,7 +194,7 @@ msgstr "কমান্ড অনুলিপি করুন"
 msgid "Copied! Paste it into a terminal and run it."
 msgstr "অনুলিপি হয়েছে। টার্মিনালে পেস্ট করে চালান।"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:32
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:33
 msgid ""
 "No VA-API encoder for your graphics card. Install your distribution’s VA-API "
 "driver."
@@ -202,194 +202,205 @@ msgstr ""
 "আপনার গ্রাফিক্স কার্ডের জন্য কোনো VA-API এনকোডার নেই। আপনার ডিস্ট্রিবিউশনের VA-API "
 "ড্রাইভার ইনস্টল করুন।"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:36
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:37
 msgid "Install the NVIDIA driver and the GStreamer nvcodec plugin."
 msgstr "NVIDIA ড্রাইভার এবং GStreamer nvcodec প্লাগইন ইনস্টল করুন।"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:39
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:40
 #, javascript-format
 msgid "The GStreamer VA-API plugin is missing. Install the %s package."
 msgstr "GStreamer VA-API প্লাগইন নেই। %s প্যাকেজ ইনস্টল করুন।"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:43
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:44
 msgid ""
 "The GStreamer VA-API plugin is missing. Install it from your distribution."
 msgstr "GStreamer VA-API প্লাগইন নেই। এটি আপনার ডিস্ট্রিবিউশন থেকে ইনস্টল করুন।"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:62
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:70
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:74
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:81
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:71
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:139
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:146
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:147
 msgid "Automatic"
 msgstr "স্বয়ংক্রিয়"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
 msgid "Native"
 msgstr "মূল"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
 msgid "4K (2160p)"
 msgstr "4K (2160p)"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
 msgid "1440p"
 msgstr "1440p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
 msgid "1080p"
 msgstr "1080p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:68
 msgid "720p"
 msgstr "720p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:75
-msgid "Hardware only"
-msgstr "শুধু হার্ডওয়্যার"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:76
-msgid "Software only"
-msgstr "শুধু সফটওয়্যার"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:77
-msgid "VA-API (Intel, AMD)"
-msgstr "VA-API (Intel, AMD)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:78
-msgid "NVENC (NVIDIA)"
-msgstr "NVENC (NVIDIA)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
-msgid "V4L2 (Arm boards)"
-msgstr "V4L2 (Arm বোর্ড)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:84
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:73
 msgid "Advanced"
 msgstr "উন্নত"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:90
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
 msgid "Stream quality"
 msgstr "স্ট্রিমের মান"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:91
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:80
 msgid "Applied the next time a cast is started"
 msgstr "পরবর্তী কাস্ট শুরুর সময় প্রয়োগ হবে"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:85
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:15
 msgid "Maximum resolution"
 msgstr "সর্বোচ্চ রেজল্যুশন"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:86
 msgid "Above 1080p needs a hardware encoder and a matching bitrate"
 msgstr "1080p-এর উপরে হার্ডওয়্যার এনকোডার এবং উপযুক্ত বিটরেট প্রয়োজন"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
 msgid "Framerate"
 msgstr "ফ্রেম রেট"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
 msgid "Frames per second"
 msgstr "প্রতি সেকেন্ডে ফ্রেম"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
 msgid "Video bitrate"
 msgstr "ভিডিও বিটরেট"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:119
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
 msgid "kbit/s: about 4000 for 720p, 8000 for 1080p, 30000 for 4K"
 msgstr "kbit/s: 720p-এর জন্য প্রায় 4000, 1080p-এর জন্য 8000, 4K-এর জন্য 30000"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:129
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
 msgid "Audio bitrate"
 msgstr "অডিও বিটরেট"
 
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:140
+msgid "Hardware only"
+msgstr "শুধু হার্ডওয়্যার"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:141
+msgid "Software only"
+msgstr "শুধু সফটওয়্যার"
+
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:142
+msgid "VA-API (Intel, AMD)"
+msgstr "VA-API (Intel, AMD)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+msgid "NVENC (NVIDIA)"
+msgstr "NVENC (NVIDIA)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:144
+msgid "V4L2 (Arm boards)"
+msgstr "V4L2 (Arm বোর্ড)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
 msgid "Encoding"
 msgstr "এনকোডিং"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:151
 msgid "Casting fails with a message when a forced choice cannot be used"
 msgstr "নির্ধারিত পছন্দ ব্যবহার করা না গেলে কাস্ট বার্তাসহ ব্যর্থ হয়"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:148
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:156
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:46
 msgid "Video encoder"
 msgstr "ভিডিও এনকোডার"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:158
 msgid ""
 "Automatic prefers your graphics card; choose software if the picture breaks "
 "up"
 msgstr "স্বয়ংক্রিয় আপনার গ্রাফিক্স কার্ড পছন্দ করে; ছবি ভেঙে গেলে সফটওয়্যার বেছে নিন"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:161
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:56
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
+#, fuzzy
+msgid "Video codec"
+msgstr "ভিডিও এনকোডার"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
+msgid "Choose VP8 if the receiver freezes or displays a broken picture"
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
 msgid "Pixel format"
 msgstr "পিক্সেল বিন্যাস"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:162
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:181
 msgid "Automatic suits every encoder; only change this to work around a driver"
 msgstr "স্বয়ংক্রিয় সব এনকোডারের জন্য উপযুক্ত; শুধু ড্রাইভারের সমস্যা এড়াতে বদলান"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:191
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
 msgid "Hardware encoding is unavailable"
 msgstr "হার্ডওয়্যার এনকোডিং উপলব্ধ নয়"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:204
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:224
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:221
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:241
 msgid "Menu"
 msgstr "মেনু"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:61
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:225
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:73
 msgid "Show cast details"
 msgstr "কাস্টের বিবরণ দেখান"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:209
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:62
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:226
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:74
 msgid "Show the transport and codecs under the active device while casting"
 msgstr "কাস্ট করার সময় সক্রিয় ডিভাইসের নিচে ট্রান্সপোর্ট ও কোডেক দেখান"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Top bar"
 msgstr "শীর্ষ বার"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Quick settings"
 msgstr "দ্রুত সেটিংস"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:219
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:236
 msgid "General"
 msgstr "সাধারণ"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:228
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:70
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:245
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:82
 msgid "Indicator location"
 msgstr "আইকনের অবস্থান"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:229
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:246
 msgid "Show the cast icon in the top bar, or in the quick settings menu"
 msgstr "কাস্ট আইকন শীর্ষ বারে, নাকি দ্রুত সেটিংস মেনুতে দেখান"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:243
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:260
 msgid "About"
 msgstr "পরিচিতি"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:254
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:271
 #, javascript-format
 msgid "Version %s"
 msgstr "সংস্করণ %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:269
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:286
 msgid "Help"
 msgstr "সহায়তা"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:270
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:287
 msgid "Common problems and their fixes"
 msgstr "সাধারণ সমস্যা ও তার সমাধান"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:273
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:290
 msgid "Troubleshooting guide"
 msgstr "সমস্যা সমাধানের নির্দেশিকা"
 
@@ -447,7 +458,14 @@ msgstr ""
 "বেছে নিন। “vaapi” (Intel, AMD), “nvenc” (NVIDIA) এবং “v4l2” (Arm বোর্ড) একটি "
 "হার্ডওয়্যার ইন্টারফেস নির্দিষ্ট করে; পছন্দ পূরণ করা না গেলে কাস্ট বার্তাসহ ব্যর্থ হয়।"
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:57
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid ""
+"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
+"available on this computer and lets the receiver choose. Force VP8 when a "
+"receiver freezes or displays a broken picture with another codec."
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""
 "The raw video format handed to the encoder. \"auto\" offers both and lets "
 "negotiation pick whichever the chosen encoder accepts. Forcing a format "
@@ -459,7 +477,7 @@ msgstr ""
 "কাস্টিং সেই এনকোডারগুলিতে সীমাবদ্ধ হয় যেগুলি এটি গ্রহণ করে, যা বেশিরভাগ সিস্টেমে "
 "এনকোডারের ধরনও বাধ্য করার সমান।"
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:71
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:83
 msgid ""
 "Where to show the cast indicator: the top-bar tray, or the quick settings "
 "menu."

--- a/extension/gnome-shell-cast@oxygenws.com/po/bn.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/bn.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-09-02 21:09+0200\n"
+"POT-Creation-Date: 2026-09-03 08:40+0200\n"
 "PO-Revision-Date: 2026-08-14 10:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: Bengali <https://github.com/omid/gnome-shell-cast>\n"
@@ -326,13 +326,13 @@ msgstr "স্বয়ংক্রিয় আপনার গ্রাফি�
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
-#, fuzzy
 msgid "Video codec"
-msgstr "ভিডিও এনকোডার"
+msgstr "ভিডিও কোডেক"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
-msgid "Choose VP8 if the receiver freezes or displays a broken picture"
-msgstr ""
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid "Automatic lets the receiver choose from the available codecs"
+msgstr "স্বয়ংক্রিয় মোড রিসিভারকে উপলভ্য কোডেকগুলি থেকে বেছে নিতে দেয়"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
@@ -457,13 +457,6 @@ msgstr ""
 "এবং সফটওয়্যারে ফিরে যায়। গ্রাফিক্স ড্রাইভার ভাঙা বা আটকে যাওয়া ছবি দিলে সফটওয়্যার "
 "বেছে নিন। “vaapi” (Intel, AMD), “nvenc” (NVIDIA) এবং “v4l2” (Arm বোর্ড) একটি "
 "হার্ডওয়্যার ইন্টারফেস নির্দিষ্ট করে; পছন্দ পূরণ করা না গেলে কাস্ট বার্তাসহ ব্যর্থ হয়।"
-
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
-msgid ""
-"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
-"available on this computer and lets the receiver choose. Force VP8 when a "
-"receiver freezes or displays a broken picture with another codec."
-msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""

--- a/extension/gnome-shell-cast@oxygenws.com/po/de.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/de.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 1\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-09-02 21:09+0200\n"
+"POT-Creation-Date: 2026-09-03 08:40+0200\n"
 "PO-Revision-Date: 2026-08-04 00:22\n"
 "Last-Translator: \n"
 "Language-Team: German <https://github.com/omid/gnome-shell-cast>\n"
@@ -339,13 +339,13 @@ msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
-#, fuzzy
 msgid "Video codec"
-msgstr "Video-Encoder"
+msgstr "Video-Codec"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
-msgid "Choose VP8 if the receiver freezes or displays a broken picture"
-msgstr ""
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid "Automatic lets the receiver choose from the available codecs"
+msgstr "Automatisch lässt den Empfänger aus den verfügbaren Codecs wählen"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
@@ -479,13 +479,6 @@ msgstr ""
 "AMD), „nvenc“ (NVIDIA) und „v4l2“ (ARM-Geräte) legen eine Hardware-"
 "Schnittstelle fest. Die Übertragung schlägt mit einer Meldung fehl, wenn die "
 "Auswahl nicht erfüllt werden kann."
-
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
-msgid ""
-"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
-"available on this computer and lets the receiver choose. Force VP8 when a "
-"receiver freezes or displays a broken picture with another codec."
-msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""

--- a/extension/gnome-shell-cast@oxygenws.com/po/de.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/de.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 1\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-08-21 21:03+0200\n"
+"POT-Creation-Date: 2026-09-02 21:09+0200\n"
 "PO-Revision-Date: 2026-08-04 00:22\n"
 "Last-Translator: \n"
 "Language-Team: German <https://github.com/omid/gnome-shell-cast>\n"
@@ -71,20 +71,20 @@ msgstr "Encoder: %s (Software)"
 msgid "Receiver supports: %s"
 msgstr "Empfänger unterstützt: %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:446
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:447
 msgid "The cast failed."
 msgstr "Die Übertragung ist fehlgeschlagen."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:453
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
 #, javascript-format
 msgid "The device ended the session (%s)."
 msgstr "Das Gerät hat die Sitzung beendet (%s)."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:455
 msgid "The device ended the session."
 msgstr "Das Gerät hat die Sitzung beendet."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:502
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:503
 #: extension/gnome-shell-cast@oxygenws.com/lib/indicator.js:22
 #: extension/gnome-shell-cast@oxygenws.com/lib/quickIndicator.js:62
 msgid "GNOME Shell Cast"
@@ -143,7 +143,7 @@ msgid "Close"
 msgstr "Schließen"
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/errorDialog.js:40
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:266
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:283
 msgid "Report an issue"
 msgstr "Fehler melden"
 
@@ -188,7 +188,7 @@ msgstr ""
 "ihn aus."
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/setupDialog.js:43
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:265
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:282
 msgid "Homepage"
 msgstr "Webseite"
 
@@ -200,7 +200,7 @@ msgstr "Befehl kopieren"
 msgid "Copied! Paste it into a terminal and run it."
 msgstr "Kopiert! Fügen Sie ihn in ein Terminal ein und führen Sie ihn aus."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:32
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:33
 msgid ""
 "No VA-API encoder for your graphics card. Install your distribution’s VA-API "
 "driver."
@@ -208,127 +208,128 @@ msgstr ""
 "Keine VA-API-Kodierung für Ihre Grafikkarte. Installieren Sie den VA-API-"
 "Treiber Ihrer Distribution."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:36
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:37
 msgid "Install the NVIDIA driver and the GStreamer nvcodec plugin."
 msgstr "Installieren Sie den NVIDIA-Treiber und das GStreamer-nvcodec-Plugin."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:39
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:40
 #, javascript-format
 msgid "The GStreamer VA-API plugin is missing. Install the %s package."
 msgstr "Das GStreamer-VA-API-Plugin fehlt. Installieren Sie das Paket %s."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:43
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:44
 msgid ""
 "The GStreamer VA-API plugin is missing. Install it from your distribution."
 msgstr ""
 "Das GStreamer-VA-API-Plugin fehlt. Installieren Sie es über Ihre "
 "Distribution."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:62
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:70
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:74
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:81
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:71
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:139
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:146
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:147
 msgid "Automatic"
 msgstr "Automatisch"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
 msgid "Native"
 msgstr "Nativ"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
 msgid "4K (2160p)"
 msgstr "4K (2160p)"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
 msgid "1440p"
 msgstr "1440p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
 msgid "1080p"
 msgstr "1080p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:68
 msgid "720p"
 msgstr "720p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:75
-msgid "Hardware only"
-msgstr "Nur Hardware"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:76
-msgid "Software only"
-msgstr "Nur Software"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:77
-msgid "VA-API (Intel, AMD)"
-msgstr "VA-API (Intel, AMD)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:78
-msgid "NVENC (NVIDIA)"
-msgstr "NVENC (NVIDIA)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
-msgid "V4L2 (Arm boards)"
-msgstr "V4L2 (ARM-Geräte)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:84
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:73
 msgid "Advanced"
 msgstr "Erweitert"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:90
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
 msgid "Stream quality"
 msgstr "Streaming-Qualität"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:91
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:80
 msgid "Applied the next time a cast is started"
 msgstr "Wird bei der nächsten Übertragung angewendet"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:85
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:15
 msgid "Maximum resolution"
 msgstr "Maximale Auflösung"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:86
 msgid "Above 1080p needs a hardware encoder and a matching bitrate"
 msgstr ""
 "Über 1080p sind ein Hardware-Encoder und eine passende Bitrate erforderlich"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
 msgid "Framerate"
 msgstr "Bildrate"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
 msgid "Frames per second"
 msgstr "Bilder pro Sekunde"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
 msgid "Video bitrate"
 msgstr "Video-Bitrate"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:119
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
 msgid "kbit/s: about 4000 for 720p, 8000 for 1080p, 30000 for 4K"
 msgstr "kbit/s: etwa 4000 für 720p, 8000 für 1080p, 30000 für 4K"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:129
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
 msgid "Audio bitrate"
 msgstr "Audio-Bitrate"
 
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:140
+msgid "Hardware only"
+msgstr "Nur Hardware"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:141
+msgid "Software only"
+msgstr "Nur Software"
+
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:142
+msgid "VA-API (Intel, AMD)"
+msgstr "VA-API (Intel, AMD)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+msgid "NVENC (NVIDIA)"
+msgstr "NVENC (NVIDIA)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:144
+msgid "V4L2 (Arm boards)"
+msgstr "V4L2 (ARM-Geräte)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
 msgid "Encoding"
 msgstr "Kodierung"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:151
 msgid "Casting fails with a message when a forced choice cannot be used"
 msgstr ""
 "Die Übertragung schlägt mit einer Meldung fehl, wenn eine erzwungene Auswahl "
 "nicht verwendbar ist"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:148
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:156
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:46
 msgid "Video encoder"
 msgstr "Video-Encoder"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:158
 msgid ""
 "Automatic prefers your graphics card; choose software if the picture breaks "
 "up"
@@ -336,77 +337,87 @@ msgstr ""
 "Automatisch bevorzugt Ihre Grafikkarte; wählen Sie Software, wenn das Bild "
 "bricht"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:161
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:56
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
+#, fuzzy
+msgid "Video codec"
+msgstr "Video-Encoder"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
+msgid "Choose VP8 if the receiver freezes or displays a broken picture"
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
 msgid "Pixel format"
 msgstr "Pixelformat"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:162
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:181
 msgid "Automatic suits every encoder; only change this to work around a driver"
 msgstr ""
 "Automatisch passt zu jedem Encoder; ändern Sie dies nur, um einen Treiber zu "
 "umgehen"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:191
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
 msgid "Hardware encoding is unavailable"
 msgstr "Hardware-Kodierung ist nicht verfügbar"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:204
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:224
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:221
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:241
 msgid "Menu"
 msgstr "Menü"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:61
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:225
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:73
 msgid "Show cast details"
 msgstr "Übertragungsdetails anzeigen"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:209
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:62
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:226
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:74
 msgid "Show the transport and codecs under the active device while casting"
 msgstr ""
 "Während der Übertragung Transport und Codecs unter dem aktiven Gerät anzeigen"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Top bar"
 msgstr "Obere Leiste"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Quick settings"
 msgstr "Schnelleinstellungen"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:219
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:236
 msgid "General"
 msgstr "Allgemein"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:228
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:70
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:245
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:82
 msgid "Indicator location"
 msgstr "Position des Symbols"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:229
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:246
 msgid "Show the cast icon in the top bar, or in the quick settings menu"
 msgstr ""
 "Das Cast-Symbol in der oberen Leiste oder im Schnelleinstellungsmenü anzeigen"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:243
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:260
 msgid "About"
 msgstr "Info"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:254
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:271
 #, javascript-format
 msgid "Version %s"
 msgstr "Version %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:269
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:286
 msgid "Help"
 msgstr "Hilfe"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:270
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:287
 msgid "Common problems and their fixes"
 msgstr "Häufige Probleme und ihre Lösungen"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:273
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:290
 msgid "Troubleshooting guide"
 msgstr "Anleitung zur Fehlerbehebung"
 
@@ -469,7 +480,14 @@ msgstr ""
 "Schnittstelle fest. Die Übertragung schlägt mit einer Meldung fehl, wenn die "
 "Auswahl nicht erfüllt werden kann."
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:57
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid ""
+"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
+"available on this computer and lets the receiver choose. Force VP8 when a "
+"receiver freezes or displays a broken picture with another codec."
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""
 "The raw video format handed to the encoder. \"auto\" offers both and lets "
 "negotiation pick whichever the chosen encoder accepts. Forcing a format "
@@ -481,7 +499,7 @@ msgstr ""
 "Ein erzwungenes Format beschränkt die Übertragung auf Encoder, die es "
 "akzeptieren – auf den meisten Systemen legt das auch den Encoder-Typ fest."
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:71
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:83
 msgid ""
 "Where to show the cast indicator: the top-bar tray, or the quick settings "
 "menu."

--- a/extension/gnome-shell-cast@oxygenws.com/po/es.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/es.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-09-02 21:09+0200\n"
+"POT-Creation-Date: 2026-09-03 08:40+0200\n"
 "PO-Revision-Date: 2026-08-14 10:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: Spanish <https://github.com/omid/gnome-shell-cast>\n"
@@ -332,13 +332,13 @@ msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
-#, fuzzy
 msgid "Video codec"
-msgstr "Codificador de vídeo"
+msgstr "Códec de vídeo"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
-msgid "Choose VP8 if the receiver freezes or displays a broken picture"
-msgstr ""
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid "Automatic lets the receiver choose from the available codecs"
+msgstr "Automático permite al receptor elegir entre los códecs disponibles"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
@@ -473,13 +473,6 @@ msgstr ""
 "una imagen rota o entrecortada. «vaapi» (Intel, AMD), «nvenc» (NVIDIA) y "
 "«v4l2» (placas Arm) fijan una sola interfaz de hardware; la transmisión "
 "falla con un mensaje si no se puede cumplir la opción."
-
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
-msgid ""
-"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
-"available on this computer and lets the receiver choose. Force VP8 when a "
-"receiver freezes or displays a broken picture with another codec."
-msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""

--- a/extension/gnome-shell-cast@oxygenws.com/po/es.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/es.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-08-21 21:03+0200\n"
+"POT-Creation-Date: 2026-09-02 21:09+0200\n"
 "PO-Revision-Date: 2026-08-14 10:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: Spanish <https://github.com/omid/gnome-shell-cast>\n"
@@ -72,20 +72,20 @@ msgstr "Codificador: %s (software)"
 msgid "Receiver supports: %s"
 msgstr "El receptor admite: %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:446
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:447
 msgid "The cast failed."
 msgstr "La transmisión ha fallado."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:453
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
 #, javascript-format
 msgid "The device ended the session (%s)."
 msgstr "El dispositivo ha finalizado la sesión (%s)."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:455
 msgid "The device ended the session."
 msgstr "El dispositivo ha finalizado la sesión."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:502
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:503
 #: extension/gnome-shell-cast@oxygenws.com/lib/indicator.js:22
 #: extension/gnome-shell-cast@oxygenws.com/lib/quickIndicator.js:62
 msgid "GNOME Shell Cast"
@@ -142,7 +142,7 @@ msgid "Close"
 msgstr "Cerrar"
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/errorDialog.js:40
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:266
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:283
 msgid "Report an issue"
 msgstr "Informar de un error"
 
@@ -184,7 +184,7 @@ msgid "Copy the command, then paste it into a terminal and run it."
 msgstr "Copie el comando, péguelo en una terminal y ejecútelo."
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/setupDialog.js:43
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:265
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:282
 msgid "Homepage"
 msgstr "Página web"
 
@@ -196,7 +196,7 @@ msgstr "Copiar el comando"
 msgid "Copied! Paste it into a terminal and run it."
 msgstr "Copiado. Péguelo en una terminal y ejecútelo."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:32
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:33
 msgid ""
 "No VA-API encoder for your graphics card. Install your distribution’s VA-API "
 "driver."
@@ -204,204 +204,215 @@ msgstr ""
 "No hay codificador VA-API para su tarjeta gráfica. Instale el controlador VA-"
 "API de su distribución."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:36
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:37
 msgid "Install the NVIDIA driver and the GStreamer nvcodec plugin."
 msgstr "Instale el controlador NVIDIA y el plugin nvcodec de GStreamer."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:39
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:40
 #, javascript-format
 msgid "The GStreamer VA-API plugin is missing. Install the %s package."
 msgstr "Falta el plugin VA-API de GStreamer. Instale el paquete %s."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:43
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:44
 msgid ""
 "The GStreamer VA-API plugin is missing. Install it from your distribution."
 msgstr "Falta el plugin VA-API de GStreamer. Instálelo desde su distribución."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:62
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:70
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:74
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:81
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:71
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:139
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:146
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:147
 msgid "Automatic"
 msgstr "Automático"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
 msgid "Native"
 msgstr "Nativa"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
 msgid "4K (2160p)"
 msgstr "4K (2160p)"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
 msgid "1440p"
 msgstr "1440p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
 msgid "1080p"
 msgstr "1080p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:68
 msgid "720p"
 msgstr "720p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:75
-msgid "Hardware only"
-msgstr "Solo hardware"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:76
-msgid "Software only"
-msgstr "Solo software"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:77
-msgid "VA-API (Intel, AMD)"
-msgstr "VA-API (Intel, AMD)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:78
-msgid "NVENC (NVIDIA)"
-msgstr "NVENC (NVIDIA)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
-msgid "V4L2 (Arm boards)"
-msgstr "V4L2 (placas Arm)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:84
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:73
 msgid "Advanced"
 msgstr "Avanzado"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:90
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
 msgid "Stream quality"
 msgstr "Calidad de la transmisión"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:91
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:80
 msgid "Applied the next time a cast is started"
 msgstr "Se aplicará la próxima vez que se inicie una transmisión"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:85
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:15
 msgid "Maximum resolution"
 msgstr "Resolución máxima"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:86
 msgid "Above 1080p needs a hardware encoder and a matching bitrate"
 msgstr ""
 "Por encima de 1080p se necesita un codificador por hardware y una tasa de "
 "bits acorde"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
 msgid "Framerate"
 msgstr "Velocidad de fotogramas"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
 msgid "Frames per second"
 msgstr "Fotogramas por segundo"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
 msgid "Video bitrate"
 msgstr "Tasa de bits del vídeo"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:119
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
 msgid "kbit/s: about 4000 for 720p, 8000 for 1080p, 30000 for 4K"
 msgstr "kbit/s: unos 4000 para 720p, 8000 para 1080p, 30000 para 4K"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:129
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
 msgid "Audio bitrate"
 msgstr "Tasa de bits del audio"
 
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:140
+msgid "Hardware only"
+msgstr "Solo hardware"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:141
+msgid "Software only"
+msgstr "Solo software"
+
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:142
+msgid "VA-API (Intel, AMD)"
+msgstr "VA-API (Intel, AMD)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+msgid "NVENC (NVIDIA)"
+msgstr "NVENC (NVIDIA)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:144
+msgid "V4L2 (Arm boards)"
+msgstr "V4L2 (placas Arm)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
 msgid "Encoding"
 msgstr "Codificación"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:151
 msgid "Casting fails with a message when a forced choice cannot be used"
 msgstr ""
 "La transmisión falla con un mensaje cuando no se puede usar la opción forzada"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:148
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:156
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:46
 msgid "Video encoder"
 msgstr "Codificador de vídeo"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:158
 msgid ""
 "Automatic prefers your graphics card; choose software if the picture breaks "
 "up"
 msgstr ""
 "Automático prefiere su tarjeta gráfica; elija software si la imagen se rompe"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:161
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:56
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
+#, fuzzy
+msgid "Video codec"
+msgstr "Codificador de vídeo"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
+msgid "Choose VP8 if the receiver freezes or displays a broken picture"
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
 msgid "Pixel format"
 msgstr "Formato de píxel"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:162
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:181
 msgid "Automatic suits every encoder; only change this to work around a driver"
 msgstr ""
 "Automático sirve para cualquier codificador; cámbielo solo para sortear un "
 "controlador"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:191
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
 msgid "Hardware encoding is unavailable"
 msgstr "La codificación por hardware no está disponible"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:204
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:224
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:221
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:241
 msgid "Menu"
 msgstr "Menú"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:61
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:225
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:73
 msgid "Show cast details"
 msgstr "Mostrar los detalles de la transmisión"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:209
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:62
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:226
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:74
 msgid "Show the transport and codecs under the active device while casting"
 msgstr ""
 "Mostrar el transporte y los códecs bajo el dispositivo activo durante la "
 "transmisión"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Top bar"
 msgstr "Barra superior"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Quick settings"
 msgstr "Configuración rápida"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:219
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:236
 msgid "General"
 msgstr "General"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:228
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:70
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:245
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:82
 msgid "Indicator location"
 msgstr "Ubicación del icono"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:229
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:246
 msgid "Show the cast icon in the top bar, or in the quick settings menu"
 msgstr ""
 "Mostrar el icono de transmisión en la barra superior o en el menú de "
 "configuración rápida"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:243
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:260
 msgid "About"
 msgstr "Acerca de"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:254
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:271
 #, javascript-format
 msgid "Version %s"
 msgstr "Versión %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:269
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:286
 msgid "Help"
 msgstr "Ayuda"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:270
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:287
 msgid "Common problems and their fixes"
 msgstr "Problemas comunes y sus soluciones"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:273
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:290
 msgid "Troubleshooting guide"
 msgstr "Guía de resolución de problemas"
 
@@ -463,7 +474,14 @@ msgstr ""
 "«v4l2» (placas Arm) fijan una sola interfaz de hardware; la transmisión "
 "falla con un mensaje si no se puede cumplir la opción."
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:57
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid ""
+"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
+"available on this computer and lets the receiver choose. Force VP8 when a "
+"receiver freezes or displays a broken picture with another codec."
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""
 "The raw video format handed to the encoder. \"auto\" offers both and lets "
 "negotiation pick whichever the chosen encoder accepts. Forcing a format "
@@ -476,7 +494,7 @@ msgstr ""
 "lo que en la mayoría de los sistemas implica forzar también el tipo de "
 "codificador."
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:71
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:83
 msgid ""
 "Where to show the cast indicator: the top-bar tray, or the quick settings "
 "menu."

--- a/extension/gnome-shell-cast@oxygenws.com/po/fa.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/fa.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 1\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-08-21 21:03+0200\n"
+"POT-Creation-Date: 2026-09-02 21:09+0200\n"
 "PO-Revision-Date: 2026-08-04 00:22\n"
 "Last-Translator: \n"
 "Language-Team: Persian <https://github.com/omid/gnome-shell-cast>\n"
@@ -71,20 +71,20 @@ msgstr "رمزگذار: %s (نرم‌افزاری)"
 msgid "Receiver supports: %s"
 msgstr "گیرنده پشتیبانی می‌کند: %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:446
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:447
 msgid "The cast failed."
 msgstr "پخش ناموفق بود."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:453
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
 #, javascript-format
 msgid "The device ended the session (%s)."
 msgstr "دستگاه نشست را پایان داد (%s)."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:455
 msgid "The device ended the session."
 msgstr "دستگاه نشست را پایان داد."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:502
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:503
 #: extension/gnome-shell-cast@oxygenws.com/lib/indicator.js:22
 #: extension/gnome-shell-cast@oxygenws.com/lib/quickIndicator.js:62
 msgid "GNOME Shell Cast"
@@ -139,7 +139,7 @@ msgid "Close"
 msgstr "بستن"
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/errorDialog.js:40
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:266
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:283
 msgid "Report an issue"
 msgstr "گزارش مشکل"
 
@@ -181,7 +181,7 @@ msgid "Copy the command, then paste it into a terminal and run it."
 msgstr "فرمان را رونوشت کنید، سپس آن را در یک پایانه بچسبانید و اجرا کنید."
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/setupDialog.js:43
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:265
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:282
 msgid "Homepage"
 msgstr "صفحهٔ خانگی"
 
@@ -193,7 +193,7 @@ msgstr "رونوشت فرمان"
 msgid "Copied! Paste it into a terminal and run it."
 msgstr "رونوشت شد! آن را در یک پایانه بچسبانید و اجرا کنید."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:32
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:33
 msgid ""
 "No VA-API encoder for your graphics card. Install your distribution’s VA-API "
 "driver."
@@ -201,196 +201,207 @@ msgstr ""
 "رمزگذار VA-API برای کارت نگاشتاری شما موجود نیست. راه‌انداز VA-API توزیعتان "
 "را نصب کنید."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:36
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:37
 msgid "Install the NVIDIA driver and the GStreamer nvcodec plugin."
 msgstr "راه‌انداز NVIDIA و افزایهٔ nvcodec برای GStreamer را نصب کنید."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:39
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:40
 #, javascript-format
 msgid "The GStreamer VA-API plugin is missing. Install the %s package."
 msgstr "افزایهٔ VA-API برای GStreamer موجود نیست. بستهٔ %s را نصب کنید."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:43
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:44
 msgid ""
 "The GStreamer VA-API plugin is missing. Install it from your distribution."
 msgstr "افزایهٔ VA-API برای GStreamer موجود نیست. آن را از توزیع خود نصب کنید."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:62
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:70
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:74
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:81
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:71
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:139
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:146
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:147
 msgid "Automatic"
 msgstr "خودکار"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
 msgid "Native"
 msgstr "بومی"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
 msgid "4K (2160p)"
 msgstr "4K (2160p)"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
 msgid "1440p"
 msgstr "1440p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
 msgid "1080p"
 msgstr "1080p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:68
 msgid "720p"
 msgstr "720p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:75
-msgid "Hardware only"
-msgstr "فقط سخت‌افزاری"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:76
-msgid "Software only"
-msgstr "فقط نرم‌افزاری"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:77
-msgid "VA-API (Intel, AMD)"
-msgstr "VA-API (Intel، AMD)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:78
-msgid "NVENC (NVIDIA)"
-msgstr "NVENC (NVIDIA)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
-msgid "V4L2 (Arm boards)"
-msgstr "V4L2 (بردهای Arm)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:84
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:73
 msgid "Advanced"
 msgstr "پیش‌رفته"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:90
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
 msgid "Stream quality"
 msgstr "کیفیت جریان"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:91
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:80
 msgid "Applied the next time a cast is started"
 msgstr "در پخش بعدی اعمال می‌شود"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:85
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:15
 msgid "Maximum resolution"
 msgstr "بیشینهٔ تفکیک‌پذیری"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:86
 msgid "Above 1080p needs a hardware encoder and a matching bitrate"
 msgstr "بالاتر از 1080p به رمزگذار سخت‌افزاری و نرخ بیت متناسب نیاز دارد"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
 msgid "Framerate"
 msgstr "نرخ فریم"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
 msgid "Frames per second"
 msgstr "فریم بر ثانیه"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
 msgid "Video bitrate"
 msgstr "نرخ بیت ویدیو"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:119
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
 msgid "kbit/s: about 4000 for 720p, 8000 for 1080p, 30000 for 4K"
 msgstr "kbit/s: حدود 4000 برای 720p، 8000 برای 1080p، 30000 برای 4K"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:129
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
 msgid "Audio bitrate"
 msgstr "نرخ بیت صدا"
 
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:140
+msgid "Hardware only"
+msgstr "فقط سخت‌افزاری"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:141
+msgid "Software only"
+msgstr "فقط نرم‌افزاری"
+
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:142
+msgid "VA-API (Intel, AMD)"
+msgstr "VA-API (Intel، AMD)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+msgid "NVENC (NVIDIA)"
+msgstr "NVENC (NVIDIA)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:144
+msgid "V4L2 (Arm boards)"
+msgstr "V4L2 (بردهای Arm)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
 msgid "Encoding"
 msgstr "رمزگذاری"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:151
 msgid "Casting fails with a message when a forced choice cannot be used"
 msgstr "اگر گزینهٔ اجباری قابل استفاده نباشد، پخش با یک پیام شکست می‌خورد"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:148
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:156
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:46
 msgid "Video encoder"
 msgstr "رمزگذار ویدیو"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:158
 msgid ""
 "Automatic prefers your graphics card; choose software if the picture breaks "
 "up"
 msgstr ""
 "خودکار کارت گرافیک شما را ترجیح می‌دهد؛ اگر تصویر خرد شد نرم‌افزاری را برگزینید"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:161
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:56
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
+#, fuzzy
+msgid "Video codec"
+msgstr "رمزگذار ویدیو"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
+msgid "Choose VP8 if the receiver freezes or displays a broken picture"
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
 msgid "Pixel format"
 msgstr "قالب پیکسل"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:162
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:181
 msgid "Automatic suits every encoder; only change this to work around a driver"
 msgstr ""
 "خودکار برای هر رمزگذاری مناسب است؛ تنها برای دور زدن یک راه‌انداز تغییرش دهید"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:191
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
 msgid "Hardware encoding is unavailable"
 msgstr "رمزگذاری سخت‌افزاری موجود نیست"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:204
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:224
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:221
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:241
 msgid "Menu"
 msgstr "منو"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:61
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:225
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:73
 msgid "Show cast details"
 msgstr "نمایش جزئیات پخش"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:209
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:62
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:226
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:74
 msgid "Show the transport and codecs under the active device while casting"
 msgstr "نمایش انتقال و کدک‌ها زیر دستگاه فعال هنگام پخش"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Top bar"
 msgstr "نوار بالا"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Quick settings"
 msgstr "تنظیمات سریع"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:219
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:236
 msgid "General"
 msgstr "عمومی"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:228
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:70
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:245
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:82
 msgid "Indicator location"
 msgstr "موقعیت نشانگر"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:229
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:246
 msgid "Show the cast icon in the top bar, or in the quick settings menu"
 msgstr "نمایش نماد پخش در نوار بالا یا در منوی تنظیمات سریع"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:243
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:260
 msgid "About"
 msgstr "درباره"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:254
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:271
 #, javascript-format
 msgid "Version %s"
 msgstr "نسخهٔ %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:269
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:286
 msgid "Help"
 msgstr "راهنما"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:270
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:287
 msgid "Common problems and their fixes"
 msgstr "مشکلات رایج و راه‌حل آن‌ها"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:273
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:290
 msgid "Troubleshooting guide"
 msgstr "راهنمای عیب‌یابی"
 
@@ -449,7 +460,14 @@ msgstr ""
 "(NVIDIA) و «v4l2» (بردهای Arm) یک واسط سخت‌افزاری را تثبیت می‌کنند؛ اگر گزینه "
 "برآورده نشود، پخش با یک پیام شکست می‌خورد."
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:57
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid ""
+"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
+"available on this computer and lets the receiver choose. Force VP8 when a "
+"receiver freezes or displays a broken picture with another codec."
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""
 "The raw video format handed to the encoder. \"auto\" offers both and lets "
 "negotiation pick whichever the chosen encoder accepts. Forcing a format "
@@ -461,7 +479,7 @@ msgstr ""
 "یک قالب، پخش را به رمزگذارهایی محدود می‌کند که آن را می‌پذیرند و در بیشتر "
 "سامانه‌ها یعنی تحمیل نوع رمزگذار هم."
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:71
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:83
 msgid ""
 "Where to show the cast indicator: the top-bar tray, or the quick settings "
 "menu."

--- a/extension/gnome-shell-cast@oxygenws.com/po/fa.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/fa.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 1\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-09-02 21:09+0200\n"
+"POT-Creation-Date: 2026-09-03 08:40+0200\n"
 "PO-Revision-Date: 2026-08-04 00:22\n"
 "Last-Translator: \n"
 "Language-Team: Persian <https://github.com/omid/gnome-shell-cast>\n"
@@ -326,13 +326,13 @@ msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
-#, fuzzy
 msgid "Video codec"
-msgstr "رمزگذار ویدیو"
+msgstr "کدک ویدیو"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
-msgid "Choose VP8 if the receiver freezes or displays a broken picture"
-msgstr ""
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid "Automatic lets the receiver choose from the available codecs"
+msgstr "حالت خودکار به گیرنده اجازه می‌دهد از میان کدک‌های موجود انتخاب کند"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
@@ -459,13 +459,6 @@ msgstr ""
 "بریده‌بریده می‌سازد، نرم‌افزاری را برگزینید. «vaapi» (Intel، AMD) و «nvenc» "
 "(NVIDIA) و «v4l2» (بردهای Arm) یک واسط سخت‌افزاری را تثبیت می‌کنند؛ اگر گزینه "
 "برآورده نشود، پخش با یک پیام شکست می‌خورد."
-
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
-msgid ""
-"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
-"available on this computer and lets the receiver choose. Force VP8 when a "
-"receiver freezes or displays a broken picture with another codec."
-msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""

--- a/extension/gnome-shell-cast@oxygenws.com/po/fr.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/fr.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-08-21 21:03+0200\n"
+"POT-Creation-Date: 2026-09-02 21:09+0200\n"
 "PO-Revision-Date: 2026-08-14 10:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: French <https://github.com/omid/gnome-shell-cast>\n"
@@ -72,20 +72,20 @@ msgstr "Encodeur : %s (logiciel)"
 msgid "Receiver supports: %s"
 msgstr "Le récepteur prend en charge : %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:446
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:447
 msgid "The cast failed."
 msgstr "La diffusion a échoué."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:453
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
 #, javascript-format
 msgid "The device ended the session (%s)."
 msgstr "L’appareil a mis fin à la session (%s)."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:455
 msgid "The device ended the session."
 msgstr "L’appareil a mis fin à la session."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:502
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:503
 #: extension/gnome-shell-cast@oxygenws.com/lib/indicator.js:22
 #: extension/gnome-shell-cast@oxygenws.com/lib/quickIndicator.js:62
 msgid "GNOME Shell Cast"
@@ -142,7 +142,7 @@ msgid "Close"
 msgstr "Fermer"
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/errorDialog.js:40
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:266
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:283
 msgid "Report an issue"
 msgstr "Signaler un problème"
 
@@ -184,7 +184,7 @@ msgid "Copy the command, then paste it into a terminal and run it."
 msgstr "Copiez la commande, collez-la dans un terminal puis exécutez-la."
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/setupDialog.js:43
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:265
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:282
 msgid "Homepage"
 msgstr "Site web"
 
@@ -196,7 +196,7 @@ msgstr "Copier la commande"
 msgid "Copied! Paste it into a terminal and run it."
 msgstr "Copié. Collez-la dans un terminal puis exécutez-la."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:32
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:33
 msgid ""
 "No VA-API encoder for your graphics card. Install your distribution’s VA-API "
 "driver."
@@ -204,126 +204,127 @@ msgstr ""
 "Aucun encodeur VA-API pour votre carte graphique. Installez le pilote VA-API "
 "de votre distribution."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:36
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:37
 msgid "Install the NVIDIA driver and the GStreamer nvcodec plugin."
 msgstr "Installez le pilote NVIDIA et le greffon nvcodec de GStreamer."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:39
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:40
 #, javascript-format
 msgid "The GStreamer VA-API plugin is missing. Install the %s package."
 msgstr "Le greffon VA-API de GStreamer est absent. Installez le paquet %s."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:43
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:44
 msgid ""
 "The GStreamer VA-API plugin is missing. Install it from your distribution."
 msgstr ""
 "Le greffon VA-API de GStreamer est absent. Installez-le depuis votre "
 "distribution."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:62
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:70
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:74
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:81
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:71
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:139
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:146
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:147
 msgid "Automatic"
 msgstr "Automatique"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
 msgid "Native"
 msgstr "Native"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
 msgid "4K (2160p)"
 msgstr "4K (2160p)"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
 msgid "1440p"
 msgstr "1440p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
 msgid "1080p"
 msgstr "1080p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:68
 msgid "720p"
 msgstr "720p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:75
-msgid "Hardware only"
-msgstr "Matériel uniquement"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:76
-msgid "Software only"
-msgstr "Logiciel uniquement"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:77
-msgid "VA-API (Intel, AMD)"
-msgstr "VA-API (Intel, AMD)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:78
-msgid "NVENC (NVIDIA)"
-msgstr "NVENC (NVIDIA)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
-msgid "V4L2 (Arm boards)"
-msgstr "V4L2 (cartes Arm)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:84
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:73
 msgid "Advanced"
 msgstr "Avancé"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:90
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
 msgid "Stream quality"
 msgstr "Qualité du flux"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:91
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:80
 msgid "Applied the next time a cast is started"
 msgstr "Appliqué au démarrage de la prochaine diffusion"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:85
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:15
 msgid "Maximum resolution"
 msgstr "Résolution maximale"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:86
 msgid "Above 1080p needs a hardware encoder and a matching bitrate"
 msgstr ""
 "Au-delà de 1080p, un encodeur matériel et un débit adapté sont nécessaires"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
 msgid "Framerate"
 msgstr "Fréquence d’images"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
 msgid "Frames per second"
 msgstr "Images par seconde"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
 msgid "Video bitrate"
 msgstr "Débit vidéo"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:119
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
 msgid "kbit/s: about 4000 for 720p, 8000 for 1080p, 30000 for 4K"
 msgstr "kbit/s : environ 4000 pour 720p, 8000 pour 1080p, 30000 pour 4K"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:129
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
 msgid "Audio bitrate"
 msgstr "Débit audio"
 
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:140
+msgid "Hardware only"
+msgstr "Matériel uniquement"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:141
+msgid "Software only"
+msgstr "Logiciel uniquement"
+
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:142
+msgid "VA-API (Intel, AMD)"
+msgstr "VA-API (Intel, AMD)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+msgid "NVENC (NVIDIA)"
+msgstr "NVENC (NVIDIA)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:144
+msgid "V4L2 (Arm boards)"
+msgstr "V4L2 (cartes Arm)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
 msgid "Encoding"
 msgstr "Encodage"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:151
 msgid "Casting fails with a message when a forced choice cannot be used"
 msgstr ""
 "La diffusion échoue avec un message lorsqu’un choix imposé est inutilisable"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:148
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:156
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:46
 msgid "Video encoder"
 msgstr "Encodeur vidéo"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:158
 msgid ""
 "Automatic prefers your graphics card; choose software if the picture breaks "
 "up"
@@ -331,79 +332,89 @@ msgstr ""
 "Automatique privilégie votre carte graphique ; choisissez logiciel si "
 "l’image se dégrade"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:161
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:56
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
+#, fuzzy
+msgid "Video codec"
+msgstr "Encodeur vidéo"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
+msgid "Choose VP8 if the receiver freezes or displays a broken picture"
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
 msgid "Pixel format"
 msgstr "Format de pixel"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:162
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:181
 msgid "Automatic suits every encoder; only change this to work around a driver"
 msgstr ""
 "Automatique convient à tous les encodeurs ; ne le changez que pour "
 "contourner un pilote"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:191
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
 msgid "Hardware encoding is unavailable"
 msgstr "L’encodage matériel n’est pas disponible"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:204
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:224
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:221
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:241
 msgid "Menu"
 msgstr "Menu"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:61
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:225
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:73
 msgid "Show cast details"
 msgstr "Afficher les détails de la diffusion"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:209
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:62
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:226
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:74
 msgid "Show the transport and codecs under the active device while casting"
 msgstr ""
 "Afficher le transport et les codecs sous l’appareil actif pendant la "
 "diffusion"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Top bar"
 msgstr "Barre supérieure"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Quick settings"
 msgstr "Paramètres rapides"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:219
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:236
 msgid "General"
 msgstr "Général"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:228
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:70
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:245
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:82
 msgid "Indicator location"
 msgstr "Emplacement de l’icône"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:229
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:246
 msgid "Show the cast icon in the top bar, or in the quick settings menu"
 msgstr ""
 "Afficher l’icône de diffusion dans la barre supérieure ou dans le menu des "
 "paramètres rapides"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:243
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:260
 msgid "About"
 msgstr "À propos"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:254
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:271
 #, javascript-format
 msgid "Version %s"
 msgstr "Version %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:269
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:286
 msgid "Help"
 msgstr "Aide"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:270
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:287
 msgid "Common problems and their fixes"
 msgstr "Problèmes courants et leurs solutions"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:273
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:290
 msgid "Troubleshooting guide"
 msgstr "Guide de dépannage"
 
@@ -466,7 +477,14 @@ msgstr ""
 "(NVIDIA) et « v4l2 » (cartes Arm) imposent une seule interface matérielle ; "
 "la diffusion échoue avec un message si le choix ne peut être satisfait."
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:57
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid ""
+"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
+"available on this computer and lets the receiver choose. Force VP8 when a "
+"receiver freezes or displays a broken picture with another codec."
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""
 "The raw video format handed to the encoder. \"auto\" offers both and lets "
 "negotiation pick whichever the chosen encoder accepts. Forcing a format "
@@ -478,7 +496,7 @@ msgstr ""
 "format limite la diffusion aux encodeurs qui l’acceptent, ce qui revient sur "
 "la plupart des systèmes à forcer aussi le type d’encodeur."
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:71
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:83
 msgid ""
 "Where to show the cast indicator: the top-bar tray, or the quick settings "
 "menu."

--- a/extension/gnome-shell-cast@oxygenws.com/po/fr.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/fr.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-09-02 21:09+0200\n"
+"POT-Creation-Date: 2026-09-03 08:40+0200\n"
 "PO-Revision-Date: 2026-08-14 10:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: French <https://github.com/omid/gnome-shell-cast>\n"
@@ -334,13 +334,13 @@ msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
-#, fuzzy
 msgid "Video codec"
-msgstr "Encodeur vidéo"
+msgstr "Codec vidéo"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
-msgid "Choose VP8 if the receiver freezes or displays a broken picture"
-msgstr ""
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid "Automatic lets the receiver choose from the available codecs"
+msgstr "Automatique permet au récepteur de choisir parmi les codecs disponibles"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
@@ -476,13 +476,6 @@ msgstr ""
 "produit une image dégradée ou saccadée. « vaapi » (Intel, AMD), « nvenc » "
 "(NVIDIA) et « v4l2 » (cartes Arm) imposent une seule interface matérielle ; "
 "la diffusion échoue avec un message si le choix ne peut être satisfait."
-
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
-msgid ""
-"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
-"available on this computer and lets the receiver choose. Force VP8 when a "
-"receiver freezes or displays a broken picture with another codec."
-msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""

--- a/extension/gnome-shell-cast@oxygenws.com/po/gnome-shell-cast@oxygenws.com.pot
+++ b/extension/gnome-shell-cast@oxygenws.com/po/gnome-shell-cast@oxygenws.com.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 4\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-09-02 21:09+0200\n"
+"POT-Creation-Date: 2026-09-03 08:40+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -319,7 +319,8 @@ msgid "Video codec"
 msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
-msgid "Choose VP8 if the receiver freezes or displays a broken picture"
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid "Automatic lets the receiver choose from the available codecs"
 msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
@@ -434,13 +435,6 @@ msgid ""
 "broken or stuttering picture. \"vaapi\" (Intel, AMD), \"nvenc\" (NVIDIA) and "
 "\"v4l2\" (Arm boards) pin one hardware API. Casting fails with a message if "
 "the choice cannot be met."
-msgstr ""
-
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
-msgid ""
-"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
-"available on this computer and lets the receiver choose. Force VP8 when a "
-"receiver freezes or displays a broken picture with another codec."
 msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69

--- a/extension/gnome-shell-cast@oxygenws.com/po/gnome-shell-cast@oxygenws.com.pot
+++ b/extension/gnome-shell-cast@oxygenws.com/po/gnome-shell-cast@oxygenws.com.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: GNOME Shell Cast 3\n"
+"Project-Id-Version: GNOME Shell Cast 4\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-08-21 21:03+0200\n"
+"POT-Creation-Date: 2026-09-02 21:09+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -74,20 +74,20 @@ msgstr ""
 msgid "Receiver supports: %s"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:446
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:447
 msgid "The cast failed."
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:453
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
 #, javascript-format
 msgid "The device ended the session (%s)."
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:455
 msgid "The device ended the session."
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:502
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:503
 #: extension/gnome-shell-cast@oxygenws.com/lib/indicator.js:22
 #: extension/gnome-shell-cast@oxygenws.com/lib/quickIndicator.js:62
 msgid "GNOME Shell Cast"
@@ -138,7 +138,7 @@ msgid "Close"
 msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/errorDialog.js:40
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:266
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:283
 msgid "Report an issue"
 msgstr ""
 
@@ -173,7 +173,7 @@ msgid "Copy the command, then paste it into a terminal and run it."
 msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/setupDialog.js:43
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:265
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:282
 msgid "Homepage"
 msgstr ""
 
@@ -185,200 +185,210 @@ msgstr ""
 msgid "Copied! Paste it into a terminal and run it."
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:32
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:33
 msgid ""
 "No VA-API encoder for your graphics card. Install your distribution’s VA-API "
 "driver."
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:36
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:37
 msgid "Install the NVIDIA driver and the GStreamer nvcodec plugin."
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:39
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:40
 #, javascript-format
 msgid "The GStreamer VA-API plugin is missing. Install the %s package."
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:43
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:44
 msgid ""
 "The GStreamer VA-API plugin is missing. Install it from your distribution."
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:62
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:70
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:74
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:81
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:71
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:139
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:146
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:147
 msgid "Automatic"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
 msgid "Native"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
 msgid "4K (2160p)"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
 msgid "1440p"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
 msgid "1080p"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:68
 msgid "720p"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:75
-msgid "Hardware only"
-msgstr ""
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:76
-msgid "Software only"
-msgstr ""
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:77
-msgid "VA-API (Intel, AMD)"
-msgstr ""
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:78
-msgid "NVENC (NVIDIA)"
-msgstr ""
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
-msgid "V4L2 (Arm boards)"
-msgstr ""
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:84
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:73
 msgid "Advanced"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:90
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
 msgid "Stream quality"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:91
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:80
 msgid "Applied the next time a cast is started"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:85
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:15
 msgid "Maximum resolution"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:86
 msgid "Above 1080p needs a hardware encoder and a matching bitrate"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
 msgid "Framerate"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
 msgid "Frames per second"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
 msgid "Video bitrate"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:119
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
 msgid "kbit/s: about 4000 for 720p, 8000 for 1080p, 30000 for 4K"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:129
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
 msgid "Audio bitrate"
 msgstr ""
 
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:140
+msgid "Hardware only"
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:141
+msgid "Software only"
+msgstr ""
+
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:142
-msgid "Encoding"
+msgid "VA-API (Intel, AMD)"
 msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+msgid "NVENC (NVIDIA)"
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:144
+msgid "V4L2 (Arm boards)"
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
+msgid "Encoding"
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:151
 msgid "Casting fails with a message when a forced choice cannot be used"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:148
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:156
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:46
 msgid "Video encoder"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:158
 msgid ""
 "Automatic prefers your graphics card; choose software if the picture breaks "
 "up"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:161
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:56
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
+msgid "Video codec"
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
+msgid "Choose VP8 if the receiver freezes or displays a broken picture"
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
 msgid "Pixel format"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:162
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:181
 msgid "Automatic suits every encoder; only change this to work around a driver"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:191
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
 msgid "Hardware encoding is unavailable"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:204
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:224
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:221
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:241
 msgid "Menu"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:61
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:225
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:73
 msgid "Show cast details"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:209
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:62
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:226
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:74
 msgid "Show the transport and codecs under the active device while casting"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Top bar"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Quick settings"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:219
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:236
 msgid "General"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:228
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:70
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:245
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:82
 msgid "Indicator location"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:229
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:246
 msgid "Show the cast icon in the top bar, or in the quick settings menu"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:243
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:260
 msgid "About"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:254
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:271
 #, javascript-format
 msgid "Version %s"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:269
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:286
 msgid "Help"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:270
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:287
 msgid "Common problems and their fixes"
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:273
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:290
 msgid "Troubleshooting guide"
 msgstr ""
 
@@ -426,7 +436,14 @@ msgid ""
 "the choice cannot be met."
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:57
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid ""
+"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
+"available on this computer and lets the receiver choose. Force VP8 when a "
+"receiver freezes or displays a broken picture with another codec."
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""
 "The raw video format handed to the encoder. \"auto\" offers both and lets "
 "negotiation pick whichever the chosen encoder accepts. Forcing a format "
@@ -434,7 +451,7 @@ msgid ""
 "forcing the encoder type too."
 msgstr ""
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:71
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:83
 msgid ""
 "Where to show the cast indicator: the top-bar tray, or the quick settings "
 "menu."

--- a/extension/gnome-shell-cast@oxygenws.com/po/hi.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/hi.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-09-02 21:09+0200\n"
+"POT-Creation-Date: 2026-09-03 08:40+0200\n"
 "PO-Revision-Date: 2026-08-14 10:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: Hindi <https://github.com/omid/gnome-shell-cast>\n"
@@ -326,13 +326,13 @@ msgstr "स्वचालित आपके ग्राफ़िक्स क
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
-#, fuzzy
 msgid "Video codec"
-msgstr "वीडियो एन्कोडर"
+msgstr "वीडियो कोडेक"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
-msgid "Choose VP8 if the receiver freezes or displays a broken picture"
-msgstr ""
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid "Automatic lets the receiver choose from the available codecs"
+msgstr "स्वचालित उपलब्ध कोडेक में से रिसीवर को चुनने देता है"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
@@ -458,13 +458,6 @@ msgstr ""
 "तस्वीर बनाए तो सॉफ़्टवेयर चुनें। “vaapi” (Intel, AMD), “nvenc” (NVIDIA) और “v4l2” "
 "(Arm बोर्ड) एक ही हार्डवेयर इंटरफ़ेस तय करते हैं; विकल्प पूरा न हो सकने पर कास्ट संदेश के "
 "साथ विफल हो जाता है।"
-
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
-msgid ""
-"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
-"available on this computer and lets the receiver choose. Force VP8 when a "
-"receiver freezes or displays a broken picture with another codec."
-msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""

--- a/extension/gnome-shell-cast@oxygenws.com/po/hi.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/hi.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-08-21 21:03+0200\n"
+"POT-Creation-Date: 2026-09-02 21:09+0200\n"
 "PO-Revision-Date: 2026-08-14 10:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: Hindi <https://github.com/omid/gnome-shell-cast>\n"
@@ -72,20 +72,20 @@ msgstr "एन्कोडर: %s (सॉफ़्टवेयर)"
 msgid "Receiver supports: %s"
 msgstr "रिसीवर समर्थन करता है: %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:446
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:447
 msgid "The cast failed."
 msgstr "कास्ट विफल रहा।"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:453
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
 #, javascript-format
 msgid "The device ended the session (%s)."
 msgstr "उपकरण ने सत्र समाप्त कर दिया (%s)।"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:455
 msgid "The device ended the session."
 msgstr "उपकरण ने सत्र समाप्त कर दिया।"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:502
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:503
 #: extension/gnome-shell-cast@oxygenws.com/lib/indicator.js:22
 #: extension/gnome-shell-cast@oxygenws.com/lib/quickIndicator.js:62
 msgid "GNOME Shell Cast"
@@ -141,7 +141,7 @@ msgid "Close"
 msgstr "बंद करें"
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/errorDialog.js:40
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:266
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:283
 msgid "Report an issue"
 msgstr "समस्या की रिपोर्ट करें"
 
@@ -182,7 +182,7 @@ msgid "Copy the command, then paste it into a terminal and run it."
 msgstr "कमांड कॉपी करें, फिर इसे टर्मिनल में चिपकाकर चलाएं।"
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/setupDialog.js:43
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:265
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:282
 msgid "Homepage"
 msgstr "वेबसाइट"
 
@@ -194,7 +194,7 @@ msgstr "कमांड कॉपी करें"
 msgid "Copied! Paste it into a terminal and run it."
 msgstr "कॉपी हो गया। इसे टर्मिनल में चिपकाकर चलाएं।"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:32
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:33
 msgid ""
 "No VA-API encoder for your graphics card. Install your distribution’s VA-API "
 "driver."
@@ -202,194 +202,205 @@ msgstr ""
 "आपके ग्राफ़िक्स कार्ड के लिए कोई VA-API एन्कोडर नहीं है। अपने वितरण का VA-API ड्राइवर "
 "स्थापित करें।"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:36
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:37
 msgid "Install the NVIDIA driver and the GStreamer nvcodec plugin."
 msgstr "NVIDIA ड्राइवर और GStreamer nvcodec प्लगइन स्थापित करें।"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:39
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:40
 #, javascript-format
 msgid "The GStreamer VA-API plugin is missing. Install the %s package."
 msgstr "GStreamer VA-API प्लगइन अनुपलब्ध है। %s पैकेज स्थापित करें।"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:43
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:44
 msgid ""
 "The GStreamer VA-API plugin is missing. Install it from your distribution."
 msgstr "GStreamer VA-API प्लगइन अनुपलब्ध है। इसे अपने वितरण से स्थापित करें।"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:62
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:70
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:74
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:81
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:71
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:139
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:146
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:147
 msgid "Automatic"
 msgstr "स्वचालित"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
 msgid "Native"
 msgstr "मूल"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
 msgid "4K (2160p)"
 msgstr "4K (2160p)"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
 msgid "1440p"
 msgstr "1440p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
 msgid "1080p"
 msgstr "1080p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:68
 msgid "720p"
 msgstr "720p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:75
-msgid "Hardware only"
-msgstr "केवल हार्डवेयर"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:76
-msgid "Software only"
-msgstr "केवल सॉफ़्टवेयर"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:77
-msgid "VA-API (Intel, AMD)"
-msgstr "VA-API (Intel, AMD)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:78
-msgid "NVENC (NVIDIA)"
-msgstr "NVENC (NVIDIA)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
-msgid "V4L2 (Arm boards)"
-msgstr "V4L2 (Arm बोर्ड)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:84
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:73
 msgid "Advanced"
 msgstr "उन्नत"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:90
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
 msgid "Stream quality"
 msgstr "स्ट्रीम गुणवत्ता"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:91
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:80
 msgid "Applied the next time a cast is started"
 msgstr "अगली बार कास्ट शुरू होने पर लागू होगा"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:85
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:15
 msgid "Maximum resolution"
 msgstr "अधिकतम रेज़ोल्यूशन"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:86
 msgid "Above 1080p needs a hardware encoder and a matching bitrate"
 msgstr "1080p से ऊपर हार्डवेयर एन्कोडर और उसके अनुरूप बिटरेट आवश्यक है"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
 msgid "Framerate"
 msgstr "फ्रेम दर"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
 msgid "Frames per second"
 msgstr "फ्रेम प्रति सेकंड"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
 msgid "Video bitrate"
 msgstr "वीडियो बिटरेट"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:119
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
 msgid "kbit/s: about 4000 for 720p, 8000 for 1080p, 30000 for 4K"
 msgstr "kbit/s: 720p के लिए लगभग 4000, 1080p के लिए 8000, 4K के लिए 30000"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:129
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
 msgid "Audio bitrate"
 msgstr "ऑडियो बिटरेट"
 
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:140
+msgid "Hardware only"
+msgstr "केवल हार्डवेयर"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:141
+msgid "Software only"
+msgstr "केवल सॉफ़्टवेयर"
+
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:142
+msgid "VA-API (Intel, AMD)"
+msgstr "VA-API (Intel, AMD)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+msgid "NVENC (NVIDIA)"
+msgstr "NVENC (NVIDIA)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:144
+msgid "V4L2 (Arm boards)"
+msgstr "V4L2 (Arm बोर्ड)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
 msgid "Encoding"
 msgstr "एन्कोडिंग"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:151
 msgid "Casting fails with a message when a forced choice cannot be used"
 msgstr "तय किया गया विकल्प उपयोग न हो सकने पर कास्ट संदेश के साथ विफल हो जाता है"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:148
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:156
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:46
 msgid "Video encoder"
 msgstr "वीडियो एन्कोडर"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:158
 msgid ""
 "Automatic prefers your graphics card; choose software if the picture breaks "
 "up"
 msgstr "स्वचालित आपके ग्राफ़िक्स कार्ड को प्राथमिकता देता है; तस्वीर टूटने पर सॉफ़्टवेयर चुनें"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:161
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:56
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
+#, fuzzy
+msgid "Video codec"
+msgstr "वीडियो एन्कोडर"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
+msgid "Choose VP8 if the receiver freezes or displays a broken picture"
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
 msgid "Pixel format"
 msgstr "पिक्सल प्रारूप"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:162
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:181
 msgid "Automatic suits every encoder; only change this to work around a driver"
 msgstr "स्वचालित हर एन्कोडर के लिए उपयुक्त है; इसे केवल किसी ड्राइवर से बचने के लिए बदलें"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:191
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
 msgid "Hardware encoding is unavailable"
 msgstr "हार्डवेयर एन्कोडिंग उपलब्ध नहीं है"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:204
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:224
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:221
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:241
 msgid "Menu"
 msgstr "मेनू"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:61
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:225
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:73
 msgid "Show cast details"
 msgstr "कास्ट विवरण दिखाएं"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:209
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:62
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:226
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:74
 msgid "Show the transport and codecs under the active device while casting"
 msgstr "कास्ट करते समय सक्रिय उपकरण के नीचे ट्रांसपोर्ट और कोडेक दिखाएं"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Top bar"
 msgstr "शीर्ष पट्टी"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Quick settings"
 msgstr "त्वरित सेटिंग"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:219
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:236
 msgid "General"
 msgstr "सामान्य"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:228
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:70
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:245
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:82
 msgid "Indicator location"
 msgstr "आइकन का स्थान"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:229
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:246
 msgid "Show the cast icon in the top bar, or in the quick settings menu"
 msgstr "कास्ट आइकन को शीर्ष पट्टी में या त्वरित सेटिंग मेनू में दिखाएं"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:243
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:260
 msgid "About"
 msgstr "परिचय"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:254
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:271
 #, javascript-format
 msgid "Version %s"
 msgstr "संस्करण %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:269
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:286
 msgid "Help"
 msgstr "सहायता"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:270
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:287
 msgid "Common problems and their fixes"
 msgstr "सामान्य समस्याएं और उनके समाधान"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:273
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:290
 msgid "Troubleshooting guide"
 msgstr "समस्या निवारण गाइड"
 
@@ -448,7 +459,14 @@ msgstr ""
 "(Arm बोर्ड) एक ही हार्डवेयर इंटरफ़ेस तय करते हैं; विकल्प पूरा न हो सकने पर कास्ट संदेश के "
 "साथ विफल हो जाता है।"
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:57
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid ""
+"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
+"available on this computer and lets the receiver choose. Force VP8 when a "
+"receiver freezes or displays a broken picture with another codec."
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""
 "The raw video format handed to the encoder. \"auto\" offers both and lets "
 "negotiation pick whichever the chosen encoder accepts. Forcing a format "
@@ -460,7 +478,7 @@ msgstr ""
 "केवल उन एन्कोडरों तक सीमित हो जाती है जो उसे स्वीकार करते हैं, जिसका अधिकांश सिस्टम पर "
 "अर्थ है एन्कोडर का प्रकार भी बाध्य करना।"
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:71
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:83
 msgid ""
 "Where to show the cast indicator: the top-bar tray, or the quick settings "
 "menu."

--- a/extension/gnome-shell-cast@oxygenws.com/po/id.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/id.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-09-02 21:09+0200\n"
+"POT-Creation-Date: 2026-09-03 08:40+0200\n"
 "PO-Revision-Date: 2026-08-14 10:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: Indonesian <https://github.com/omid/gnome-shell-cast>\n"
@@ -334,13 +334,13 @@ msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
-#, fuzzy
 msgid "Video codec"
-msgstr "Enkoder video"
+msgstr "Kodek video"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
-msgid "Choose VP8 if the receiver freezes or displays a broken picture"
-msgstr ""
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid "Automatic lets the receiver choose from the available codecs"
+msgstr "Otomatis memungkinkan penerima memilih dari kodek yang tersedia"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
@@ -472,13 +472,6 @@ msgstr ""
 "grafis menghasilkan gambar rusak atau tersendat. “vaapi” (Intel, AMD), "
 "“nvenc” (NVIDIA), dan “v4l2” (papan Arm) mengunci satu antarmuka perangkat "
 "keras; cast gagal dengan sebuah pesan bila pilihan tak dapat dipenuhi."
-
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
-msgid ""
-"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
-"available on this computer and lets the receiver choose. Force VP8 when a "
-"receiver freezes or displays a broken picture with another codec."
-msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""

--- a/extension/gnome-shell-cast@oxygenws.com/po/id.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/id.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-08-21 21:03+0200\n"
+"POT-Creation-Date: 2026-09-02 21:09+0200\n"
 "PO-Revision-Date: 2026-08-14 10:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: Indonesian <https://github.com/omid/gnome-shell-cast>\n"
@@ -72,20 +72,20 @@ msgstr "Enkoder: %s (perangkat lunak)"
 msgid "Receiver supports: %s"
 msgstr "Penerima mendukung: %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:446
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:447
 msgid "The cast failed."
 msgstr "Cast gagal."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:453
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
 #, javascript-format
 msgid "The device ended the session (%s)."
 msgstr "Perangkat mengakhiri sesi (%s)."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:455
 msgid "The device ended the session."
 msgstr "Perangkat mengakhiri sesi."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:502
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:503
 #: extension/gnome-shell-cast@oxygenws.com/lib/indicator.js:22
 #: extension/gnome-shell-cast@oxygenws.com/lib/quickIndicator.js:62
 msgid "GNOME Shell Cast"
@@ -143,7 +143,7 @@ msgid "Close"
 msgstr "Tutup"
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/errorDialog.js:40
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:266
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:283
 msgid "Report an issue"
 msgstr "Laporkan masalah"
 
@@ -185,7 +185,7 @@ msgid "Copy the command, then paste it into a terminal and run it."
 msgstr "Salin perintah, lalu tempelkan ke terminal dan jalankan."
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/setupDialog.js:43
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:265
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:282
 msgid "Homepage"
 msgstr "Situs web"
 
@@ -197,7 +197,7 @@ msgstr "Salin perintah"
 msgid "Copied! Paste it into a terminal and run it."
 msgstr "Tersalin. Tempelkan ke terminal dan jalankan."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:32
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:33
 msgid ""
 "No VA-API encoder for your graphics card. Install your distribution’s VA-API "
 "driver."
@@ -205,125 +205,126 @@ msgstr ""
 "Tidak ada enkoder VA-API untuk kartu grafis Anda. Pasang driver VA-API dari "
 "distribusi Anda."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:36
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:37
 msgid "Install the NVIDIA driver and the GStreamer nvcodec plugin."
 msgstr "Pasang driver NVIDIA dan plugin nvcodec GStreamer."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:39
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:40
 #, javascript-format
 msgid "The GStreamer VA-API plugin is missing. Install the %s package."
 msgstr "Plugin VA-API GStreamer tidak ada. Pasang paket %s."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:43
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:44
 msgid ""
 "The GStreamer VA-API plugin is missing. Install it from your distribution."
 msgstr "Plugin VA-API GStreamer tidak ada. Pasang dari distribusi Anda."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:62
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:70
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:74
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:81
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:71
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:139
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:146
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:147
 msgid "Automatic"
 msgstr "Otomatis"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
 msgid "Native"
 msgstr "Natif"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
 msgid "4K (2160p)"
 msgstr "4K (2160p)"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
 msgid "1440p"
 msgstr "1440p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
 msgid "1080p"
 msgstr "1080p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:68
 msgid "720p"
 msgstr "720p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:75
-msgid "Hardware only"
-msgstr "Hanya perangkat keras"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:76
-msgid "Software only"
-msgstr "Hanya perangkat lunak"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:77
-msgid "VA-API (Intel, AMD)"
-msgstr "VA-API (Intel, AMD)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:78
-msgid "NVENC (NVIDIA)"
-msgstr "NVENC (NVIDIA)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
-msgid "V4L2 (Arm boards)"
-msgstr "V4L2 (papan Arm)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:84
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:73
 msgid "Advanced"
 msgstr "Tingkat lanjut"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:90
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
 msgid "Stream quality"
 msgstr "Kualitas aliran"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:91
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:80
 msgid "Applied the next time a cast is started"
 msgstr "Diterapkan saat cast berikutnya dimulai"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:85
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:15
 msgid "Maximum resolution"
 msgstr "Resolusi maksimum"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:86
 msgid "Above 1080p needs a hardware encoder and a matching bitrate"
 msgstr ""
 "Di atas 1080p memerlukan enkoder perangkat keras dan bitrate yang sesuai"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
 msgid "Framerate"
 msgstr "Laju bingkai"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
 msgid "Frames per second"
 msgstr "Bingkai per detik"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
 msgid "Video bitrate"
 msgstr "Bitrate video"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:119
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
 msgid "kbit/s: about 4000 for 720p, 8000 for 1080p, 30000 for 4K"
 msgstr "kbit/s: sekitar 4000 untuk 720p, 8000 untuk 1080p, 30000 untuk 4K"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:129
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
 msgid "Audio bitrate"
 msgstr "Bitrate audio"
 
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:140
+msgid "Hardware only"
+msgstr "Hanya perangkat keras"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:141
+msgid "Software only"
+msgstr "Hanya perangkat lunak"
+
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:142
+msgid "VA-API (Intel, AMD)"
+msgstr "VA-API (Intel, AMD)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+msgid "NVENC (NVIDIA)"
+msgstr "NVENC (NVIDIA)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:144
+msgid "V4L2 (Arm boards)"
+msgstr "V4L2 (papan Arm)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
 msgid "Encoding"
 msgstr "Pengkodean"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:151
 msgid "Casting fails with a message when a forced choice cannot be used"
 msgstr ""
 "Cast gagal dengan sebuah pesan bila pilihan yang dipaksakan tidak dapat "
 "dipakai"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:148
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:156
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:46
 msgid "Video encoder"
 msgstr "Enkoder video"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:158
 msgid ""
 "Automatic prefers your graphics card; choose software if the picture breaks "
 "up"
@@ -331,76 +332,86 @@ msgstr ""
 "Otomatis mengutamakan kartu grafis Anda; pilih perangkat lunak bila gambar "
 "pecah"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:161
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:56
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
+#, fuzzy
+msgid "Video codec"
+msgstr "Enkoder video"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
+msgid "Choose VP8 if the receiver freezes or displays a broken picture"
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
 msgid "Pixel format"
 msgstr "Format piksel"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:162
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:181
 msgid "Automatic suits every encoder; only change this to work around a driver"
 msgstr ""
 "Otomatis cocok untuk semua enkoder; ubah hanya untuk menyiasati suatu "
 "penggerak"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:191
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
 msgid "Hardware encoding is unavailable"
 msgstr "Pengkodean perangkat keras tidak tersedia"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:204
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:224
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:221
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:241
 msgid "Menu"
 msgstr "Menu"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:61
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:225
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:73
 msgid "Show cast details"
 msgstr "Tampilkan detail cast"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:209
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:62
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:226
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:74
 msgid "Show the transport and codecs under the active device while casting"
 msgstr ""
 "Tampilkan transport dan kodek di bawah perangkat aktif saat melakukan cast"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Top bar"
 msgstr "Bar atas"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Quick settings"
 msgstr "Pengaturan cepat"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:219
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:236
 msgid "General"
 msgstr "Umum"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:228
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:70
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:245
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:82
 msgid "Indicator location"
 msgstr "Lokasi ikon"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:229
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:246
 msgid "Show the cast icon in the top bar, or in the quick settings menu"
 msgstr "Tampilkan ikon cast di bar atas, atau di menu pengaturan cepat"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:243
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:260
 msgid "About"
 msgstr "Tentang"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:254
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:271
 #, javascript-format
 msgid "Version %s"
 msgstr "Versi %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:269
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:286
 msgid "Help"
 msgstr "Bantuan"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:270
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:287
 msgid "Common problems and their fixes"
 msgstr "Masalah umum dan solusinya"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:273
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:290
 msgid "Troubleshooting guide"
 msgstr "Panduan pemecahan masalah"
 
@@ -462,7 +473,14 @@ msgstr ""
 "“nvenc” (NVIDIA), dan “v4l2” (papan Arm) mengunci satu antarmuka perangkat "
 "keras; cast gagal dengan sebuah pesan bila pilihan tak dapat dipenuhi."
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:57
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid ""
+"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
+"available on this computer and lets the receiver choose. Force VP8 when a "
+"receiver freezes or displays a broken picture with another codec."
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""
 "The raw video format handed to the encoder. \"auto\" offers both and lets "
 "negotiation pick whichever the chosen encoder accepts. Forcing a format "
@@ -474,7 +492,7 @@ msgstr ""
 "Memaksa suatu format membatasi penyiaran ke enkoder yang menerimanya, yang "
 "di sebagian besar sistem berarti memaksa jenis enkoder juga."
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:71
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:83
 msgid ""
 "Where to show the cast indicator: the top-bar tray, or the quick settings "
 "menu."

--- a/extension/gnome-shell-cast@oxygenws.com/po/pt_BR.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/pt_BR.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-09-02 21:09+0200\n"
+"POT-Creation-Date: 2026-09-03 08:40+0200\n"
 "PO-Revision-Date: 2026-08-14 10:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: Brazilian Portuguese <https://github.com/omid/gnome-shell-"
@@ -337,13 +337,13 @@ msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
-#, fuzzy
 msgid "Video codec"
-msgstr "Codificador de vídeo"
+msgstr "Codec de vídeo"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
-msgid "Choose VP8 if the receiver freezes or displays a broken picture"
-msgstr ""
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid "Automatic lets the receiver choose from the available codecs"
+msgstr "Automático permite que o receptor escolha entre os codecs disponíveis"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
@@ -479,13 +479,6 @@ msgstr ""
 "imagem quebrada ou travando. “vaapi” (Intel, AMD), “nvenc” (NVIDIA) e “v4l2” "
 "(placas Arm) fixam uma única interface de hardware; a transmissão falha com "
 "uma mensagem se a escolha não puder ser atendida."
-
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
-msgid ""
-"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
-"available on this computer and lets the receiver choose. Force VP8 when a "
-"receiver freezes or displays a broken picture with another codec."
-msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""

--- a/extension/gnome-shell-cast@oxygenws.com/po/pt_BR.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/pt_BR.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-08-21 21:03+0200\n"
+"POT-Creation-Date: 2026-09-02 21:09+0200\n"
 "PO-Revision-Date: 2026-08-14 10:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: Brazilian Portuguese <https://github.com/omid/gnome-shell-"
@@ -73,20 +73,20 @@ msgstr "Codificador: %s (software)"
 msgid "Receiver supports: %s"
 msgstr "O receptor tem suporte a: %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:446
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:447
 msgid "The cast failed."
 msgstr "A transmissão falhou."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:453
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
 #, javascript-format
 msgid "The device ended the session (%s)."
 msgstr "O dispositivo encerrou a sessão (%s)."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:455
 msgid "The device ended the session."
 msgstr "O dispositivo encerrou a sessão."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:502
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:503
 #: extension/gnome-shell-cast@oxygenws.com/lib/indicator.js:22
 #: extension/gnome-shell-cast@oxygenws.com/lib/quickIndicator.js:62
 msgid "GNOME Shell Cast"
@@ -144,7 +144,7 @@ msgid "Close"
 msgstr "Fechar"
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/errorDialog.js:40
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:266
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:283
 msgid "Report an issue"
 msgstr "Relatar um problema"
 
@@ -186,7 +186,7 @@ msgid "Copy the command, then paste it into a terminal and run it."
 msgstr "Copie o comando, cole-o em um terminal e execute-o."
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/setupDialog.js:43
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:265
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:282
 msgid "Homepage"
 msgstr "Site"
 
@@ -198,7 +198,7 @@ msgstr "Copiar o comando"
 msgid "Copied! Paste it into a terminal and run it."
 msgstr "Copiado. Cole-o em um terminal e execute-o."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:32
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:33
 msgid ""
 "No VA-API encoder for your graphics card. Install your distribution’s VA-API "
 "driver."
@@ -206,127 +206,128 @@ msgstr ""
 "Nenhum codificador VA-API para sua placa de vídeo. Instale o driver VA-API "
 "da sua distribuição."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:36
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:37
 msgid "Install the NVIDIA driver and the GStreamer nvcodec plugin."
 msgstr "Instale o driver NVIDIA e o plug-in nvcodec do GStreamer."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:39
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:40
 #, javascript-format
 msgid "The GStreamer VA-API plugin is missing. Install the %s package."
 msgstr "O plug-in VA-API do GStreamer está ausente. Instale o pacote %s."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:43
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:44
 msgid ""
 "The GStreamer VA-API plugin is missing. Install it from your distribution."
 msgstr ""
 "O plug-in VA-API do GStreamer está ausente. Instale-o pela sua distribuição."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:62
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:70
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:74
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:81
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:71
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:139
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:146
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:147
 msgid "Automatic"
 msgstr "Automático"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
 msgid "Native"
 msgstr "Nativa"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
 msgid "4K (2160p)"
 msgstr "4K (2160p)"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
 msgid "1440p"
 msgstr "1440p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
 msgid "1080p"
 msgstr "1080p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:68
 msgid "720p"
 msgstr "720p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:75
-msgid "Hardware only"
-msgstr "Somente hardware"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:76
-msgid "Software only"
-msgstr "Somente software"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:77
-msgid "VA-API (Intel, AMD)"
-msgstr "VA-API (Intel, AMD)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:78
-msgid "NVENC (NVIDIA)"
-msgstr "NVENC (NVIDIA)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
-msgid "V4L2 (Arm boards)"
-msgstr "V4L2 (placas Arm)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:84
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:73
 msgid "Advanced"
 msgstr "Avançado"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:90
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
 msgid "Stream quality"
 msgstr "Qualidade da transmissão"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:91
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:80
 msgid "Applied the next time a cast is started"
 msgstr "Aplicado na próxima vez que uma transmissão for iniciada"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:85
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:15
 msgid "Maximum resolution"
 msgstr "Resolução máxima"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:86
 msgid "Above 1080p needs a hardware encoder and a matching bitrate"
 msgstr ""
 "Acima de 1080p é necessário um codificador de hardware e uma taxa de bits "
 "compatível"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
 msgid "Framerate"
 msgstr "Taxa de quadros"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
 msgid "Frames per second"
 msgstr "Quadros por segundo"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
 msgid "Video bitrate"
 msgstr "Taxa de bits do vídeo"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:119
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
 msgid "kbit/s: about 4000 for 720p, 8000 for 1080p, 30000 for 4K"
 msgstr "kbit/s: cerca de 4000 para 720p, 8000 para 1080p, 30000 para 4K"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:129
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
 msgid "Audio bitrate"
 msgstr "Taxa de bits do áudio"
 
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:140
+msgid "Hardware only"
+msgstr "Somente hardware"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:141
+msgid "Software only"
+msgstr "Somente software"
+
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:142
+msgid "VA-API (Intel, AMD)"
+msgstr "VA-API (Intel, AMD)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+msgid "NVENC (NVIDIA)"
+msgstr "NVENC (NVIDIA)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:144
+msgid "V4L2 (Arm boards)"
+msgstr "V4L2 (placas Arm)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
 msgid "Encoding"
 msgstr "Codificação"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:151
 msgid "Casting fails with a message when a forced choice cannot be used"
 msgstr ""
 "A transmissão falha com uma mensagem quando uma escolha forçada não pode ser "
 "usada"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:148
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:156
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:46
 msgid "Video encoder"
 msgstr "Codificador de vídeo"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:158
 msgid ""
 "Automatic prefers your graphics card; choose software if the picture breaks "
 "up"
@@ -334,79 +335,89 @@ msgstr ""
 "Automático prefere sua placa de vídeo; escolha software se a imagem se "
 "quebrar"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:161
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:56
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
+#, fuzzy
+msgid "Video codec"
+msgstr "Codificador de vídeo"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
+msgid "Choose VP8 if the receiver freezes or displays a broken picture"
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
 msgid "Pixel format"
 msgstr "Formato de pixel"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:162
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:181
 msgid "Automatic suits every encoder; only change this to work around a driver"
 msgstr ""
 "Automático serve para qualquer codificador; mude apenas para contornar um "
 "driver"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:191
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
 msgid "Hardware encoding is unavailable"
 msgstr "A codificação por hardware não está disponível"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:204
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:224
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:221
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:241
 msgid "Menu"
 msgstr "Menu"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:61
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:225
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:73
 msgid "Show cast details"
 msgstr "Mostrar detalhes da transmissão"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:209
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:62
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:226
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:74
 msgid "Show the transport and codecs under the active device while casting"
 msgstr ""
 "Mostrar o transporte e os codecs abaixo do dispositivo ativo durante a "
 "transmissão"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Top bar"
 msgstr "Barra superior"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Quick settings"
 msgstr "Configurações rápidas"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:219
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:236
 msgid "General"
 msgstr "Geral"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:228
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:70
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:245
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:82
 msgid "Indicator location"
 msgstr "Localização do ícone"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:229
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:246
 msgid "Show the cast icon in the top bar, or in the quick settings menu"
 msgstr ""
 "Mostrar o ícone de transmissão na barra superior ou no menu de configurações "
 "rápidas"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:243
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:260
 msgid "About"
 msgstr "Sobre"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:254
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:271
 #, javascript-format
 msgid "Version %s"
 msgstr "Versão %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:269
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:286
 msgid "Help"
 msgstr "Ajuda"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:270
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:287
 msgid "Common problems and their fixes"
 msgstr "Problemas comuns e suas soluções"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:273
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:290
 msgid "Troubleshooting guide"
 msgstr "Guia de solução de problemas"
 
@@ -469,7 +480,14 @@ msgstr ""
 "(placas Arm) fixam uma única interface de hardware; a transmissão falha com "
 "uma mensagem se a escolha não puder ser atendida."
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:57
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid ""
+"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
+"available on this computer and lets the receiver choose. Force VP8 when a "
+"receiver freezes or displays a broken picture with another codec."
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""
 "The raw video format handed to the encoder. \"auto\" offers both and lets "
 "negotiation pick whichever the chosen encoder accepts. Forcing a format "
@@ -481,7 +499,7 @@ msgstr ""
 "um formato restringe a transmissão aos codificadores que o aceitam, o que na "
 "maioria dos sistemas significa forçar também o tipo de codificador."
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:71
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:83
 msgid ""
 "Where to show the cast indicator: the top-bar tray, or the quick settings "
 "menu."

--- a/extension/gnome-shell-cast@oxygenws.com/po/ru.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/ru.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-08-21 21:03+0200\n"
+"POT-Creation-Date: 2026-09-02 21:09+0200\n"
 "PO-Revision-Date: 2026-08-14 10:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: Russian <https://github.com/omid/gnome-shell-cast>\n"
@@ -73,20 +73,20 @@ msgstr "Кодировщик: %s (программный)"
 msgid "Receiver supports: %s"
 msgstr "Приёмник поддерживает: %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:446
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:447
 msgid "The cast failed."
 msgstr "Не удалось выполнить трансляцию."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:453
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
 #, javascript-format
 msgid "The device ended the session (%s)."
 msgstr "Устройство завершило сеанс (%s)."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:455
 msgid "The device ended the session."
 msgstr "Устройство завершило сеанс."
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:502
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:503
 #: extension/gnome-shell-cast@oxygenws.com/lib/indicator.js:22
 #: extension/gnome-shell-cast@oxygenws.com/lib/quickIndicator.js:62
 msgid "GNOME Shell Cast"
@@ -141,7 +141,7 @@ msgid "Close"
 msgstr "Закрыть"
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/errorDialog.js:40
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:266
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:283
 msgid "Report an issue"
 msgstr "Сообщить о проблеме"
 
@@ -183,7 +183,7 @@ msgid "Copy the command, then paste it into a terminal and run it."
 msgstr "Скопируйте команду, вставьте её в терминал и выполните."
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/setupDialog.js:43
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:265
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:282
 msgid "Homepage"
 msgstr "Веб-сайт"
 
@@ -195,7 +195,7 @@ msgstr "Копировать команду"
 msgid "Copied! Paste it into a terminal and run it."
 msgstr "Скопировано. Вставьте в терминал и выполните."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:32
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:33
 msgid ""
 "No VA-API encoder for your graphics card. Install your distribution’s VA-API "
 "driver."
@@ -203,126 +203,127 @@ msgstr ""
 "Нет кодировщика VA-API для вашего видеоадаптера. Установите драйвер VA-API "
 "из вашего дистрибутива."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:36
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:37
 msgid "Install the NVIDIA driver and the GStreamer nvcodec plugin."
 msgstr "Установите драйвер NVIDIA и модуль nvcodec для GStreamer."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:39
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:40
 #, javascript-format
 msgid "The GStreamer VA-API plugin is missing. Install the %s package."
 msgstr "Отсутствует модуль VA-API для GStreamer. Установите пакет %s."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:43
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:44
 msgid ""
 "The GStreamer VA-API plugin is missing. Install it from your distribution."
 msgstr ""
 "Отсутствует модуль VA-API для GStreamer. Установите его средствами вашего "
 "дистрибутива."
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:62
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:70
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:74
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:81
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:71
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:139
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:146
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:147
 msgid "Automatic"
 msgstr "Автоматически"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
 msgid "Native"
 msgstr "Исходное"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
 msgid "4K (2160p)"
 msgstr "4K (2160p)"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
 msgid "1440p"
 msgstr "1440p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
 msgid "1080p"
 msgstr "1080p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:68
 msgid "720p"
 msgstr "720p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:75
-msgid "Hardware only"
-msgstr "Только аппаратный"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:76
-msgid "Software only"
-msgstr "Только программный"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:77
-msgid "VA-API (Intel, AMD)"
-msgstr "VA-API (Intel, AMD)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:78
-msgid "NVENC (NVIDIA)"
-msgstr "NVENC (NVIDIA)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
-msgid "V4L2 (Arm boards)"
-msgstr "V4L2 (платы Arm)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:84
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:73
 msgid "Advanced"
 msgstr "Дополнительно"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:90
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
 msgid "Stream quality"
 msgstr "Качество трансляции"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:91
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:80
 msgid "Applied the next time a cast is started"
 msgstr "Применяется при следующем запуске трансляции"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:85
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:15
 msgid "Maximum resolution"
 msgstr "Максимальное разрешение"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:86
 msgid "Above 1080p needs a hardware encoder and a matching bitrate"
 msgstr "Выше 1080p требуется аппаратный кодировщик и соответствующий битрейт"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
 msgid "Framerate"
 msgstr "Частота кадров"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
 msgid "Frames per second"
 msgstr "Кадров в секунду"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
 msgid "Video bitrate"
 msgstr "Битрейт видео"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:119
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
 msgid "kbit/s: about 4000 for 720p, 8000 for 1080p, 30000 for 4K"
 msgstr "кбит/с: около 4000 для 720p, 8000 для 1080p, 30000 для 4K"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:129
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
 msgid "Audio bitrate"
 msgstr "Битрейт аудио"
 
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:140
+msgid "Hardware only"
+msgstr "Только аппаратный"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:141
+msgid "Software only"
+msgstr "Только программный"
+
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:142
+msgid "VA-API (Intel, AMD)"
+msgstr "VA-API (Intel, AMD)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+msgid "NVENC (NVIDIA)"
+msgstr "NVENC (NVIDIA)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:144
+msgid "V4L2 (Arm boards)"
+msgstr "V4L2 (платы Arm)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
 msgid "Encoding"
 msgstr "Кодирование"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:151
 msgid "Casting fails with a message when a forced choice cannot be used"
 msgstr ""
 "Трансляция завершается с сообщением, когда заданный выбор невозможно "
 "использовать"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:148
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:156
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:46
 msgid "Video encoder"
 msgstr "Кодировщик видео"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:158
 msgid ""
 "Automatic prefers your graphics card; choose software if the picture breaks "
 "up"
@@ -330,77 +331,87 @@ msgstr ""
 "Автоматически предпочитает видеокарту; выберите программный, если "
 "изображение рассыпается"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:161
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:56
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
+#, fuzzy
+msgid "Video codec"
+msgstr "Кодировщик видео"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
+msgid "Choose VP8 if the receiver freezes or displays a broken picture"
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
 msgid "Pixel format"
 msgstr "Формат пикселей"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:162
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:181
 msgid "Automatic suits every encoder; only change this to work around a driver"
 msgstr ""
 "Автоматически подходит любому кодировщику; меняйте только чтобы обойти "
 "драйвер"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:191
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
 msgid "Hardware encoding is unavailable"
 msgstr "Аппаратное кодирование недоступно"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:204
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:224
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:221
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:241
 msgid "Menu"
 msgstr "Меню"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:61
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:225
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:73
 msgid "Show cast details"
 msgstr "Показывать сведения о трансляции"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:209
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:62
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:226
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:74
 msgid "Show the transport and codecs under the active device while casting"
 msgstr ""
 "Показывать транспорт и кодеки под активным устройством во время трансляции"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Top bar"
 msgstr "Верхняя панель"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Quick settings"
 msgstr "Быстрые настройки"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:219
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:236
 msgid "General"
 msgstr "Общие"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:228
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:70
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:245
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:82
 msgid "Indicator location"
 msgstr "Расположение значка"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:229
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:246
 msgid "Show the cast icon in the top bar, or in the quick settings menu"
 msgstr ""
 "Показывать значок трансляции на верхней панели или в меню быстрых настроек"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:243
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:260
 msgid "About"
 msgstr "О программе"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:254
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:271
 #, javascript-format
 msgid "Version %s"
 msgstr "Версия %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:269
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:286
 msgid "Help"
 msgstr "Справка"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:270
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:287
 msgid "Common problems and their fixes"
 msgstr "Частые проблемы и их решения"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:273
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:290
 msgid "Troubleshooting guide"
 msgstr "Руководство по устранению неполадок"
 
@@ -462,7 +473,14 @@ msgstr ""
 "аппаратный интерфейс; трансляция завершается с сообщением, если выбор "
 "невозможно выполнить."
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:57
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid ""
+"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
+"available on this computer and lets the receiver choose. Force VP8 when a "
+"receiver freezes or displays a broken picture with another codec."
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""
 "The raw video format handed to the encoder. \"auto\" offers both and lets "
 "negotiation pick whichever the chosen encoder accepts. Forcing a format "
@@ -475,7 +493,7 @@ msgstr ""
 "которые его принимают, что на большинстве систем означает принудительный "
 "выбор и типа кодировщика."
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:71
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:83
 msgid ""
 "Where to show the cast indicator: the top-bar tray, or the quick settings "
 "menu."

--- a/extension/gnome-shell-cast@oxygenws.com/po/ru.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/ru.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-09-02 21:09+0200\n"
+"POT-Creation-Date: 2026-09-03 08:40+0200\n"
 "PO-Revision-Date: 2026-08-14 10:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: Russian <https://github.com/omid/gnome-shell-cast>\n"
@@ -333,13 +333,13 @@ msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
-#, fuzzy
 msgid "Video codec"
-msgstr "Кодировщик видео"
+msgstr "Видеокодек"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
-msgid "Choose VP8 if the receiver freezes or displays a broken picture"
-msgstr ""
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid "Automatic lets the receiver choose from the available codecs"
+msgstr "Автоматический режим позволяет приёмнику выбрать один из доступных кодеков"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
@@ -472,13 +472,6 @@ msgstr ""
 "(Intel, AMD), «nvenc» (NVIDIA) и «v4l2» (платы Arm) закрепляют один "
 "аппаратный интерфейс; трансляция завершается с сообщением, если выбор "
 "невозможно выполнить."
-
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
-msgid ""
-"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
-"available on this computer and lets the receiver choose. Force VP8 when a "
-"receiver freezes or displays a broken picture with another codec."
-msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""

--- a/extension/gnome-shell-cast@oxygenws.com/po/ur.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/ur.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-09-02 21:09+0200\n"
+"POT-Creation-Date: 2026-09-03 08:40+0200\n"
 "PO-Revision-Date: 2026-08-14 10:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: Urdu <https://github.com/omid/gnome-shell-cast>\n"
@@ -333,13 +333,13 @@ msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
-#, fuzzy
 msgid "Video codec"
-msgstr "وڈیو اینکوڈر"
+msgstr "ویڈیو کوڈیک"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
-msgid "Choose VP8 if the receiver freezes or displays a broken picture"
-msgstr ""
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid "Automatic lets the receiver choose from the available codecs"
+msgstr "خودکار دستیاب کوڈیکس میں سے وصول کنندہ کو انتخاب کرنے دیتا ہے"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
@@ -469,13 +469,6 @@ msgstr ""
 "بنائے تو سافٹ ویئر منتخب کریں۔ ”vaapi“ (Intel، AMD)، ”nvenc“ (NVIDIA) اور "
 "”v4l2“ (Arm بورڈ) ایک ہارڈویئر انٹرفیس مقرر کرتے ہیں؛ انتخاب پورا نہ ہو سکے "
 "تو کاسٹ ایک پیغام کے ساتھ ناکام ہو جاتی ہے۔"
-
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
-msgid ""
-"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
-"available on this computer and lets the receiver choose. Force VP8 when a "
-"receiver freezes or displays a broken picture with another codec."
-msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""

--- a/extension/gnome-shell-cast@oxygenws.com/po/ur.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/ur.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-08-21 21:03+0200\n"
+"POT-Creation-Date: 2026-09-02 21:09+0200\n"
 "PO-Revision-Date: 2026-08-14 10:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: Urdu <https://github.com/omid/gnome-shell-cast>\n"
@@ -72,20 +72,20 @@ msgstr "اینکوڈر: %s (سافٹ ویئر)"
 msgid "Receiver supports: %s"
 msgstr "وصول کنندہ معاونت کرتا ہے: %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:446
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:447
 msgid "The cast failed."
 msgstr "کاسٹ ناکام ہو گیا۔"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:453
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
 #, javascript-format
 msgid "The device ended the session (%s)."
 msgstr "آلے نے سیشن ختم کر دیا (%s)۔"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:455
 msgid "The device ended the session."
 msgstr "آلے نے سیشن ختم کر دیا۔"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:502
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:503
 #: extension/gnome-shell-cast@oxygenws.com/lib/indicator.js:22
 #: extension/gnome-shell-cast@oxygenws.com/lib/quickIndicator.js:62
 msgid "GNOME Shell Cast"
@@ -142,7 +142,7 @@ msgid "Close"
 msgstr "بند کریں"
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/errorDialog.js:40
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:266
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:283
 msgid "Report an issue"
 msgstr "مسئلے کی اطلاع دیں"
 
@@ -184,7 +184,7 @@ msgid "Copy the command, then paste it into a terminal and run it."
 msgstr "کمانڈ نقل کریں، پھر اسے ٹرمینل میں چسپاں کر کے چلائیں۔"
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/setupDialog.js:43
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:265
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:282
 msgid "Homepage"
 msgstr "ویب سائٹ"
 
@@ -196,7 +196,7 @@ msgstr "کمانڈ نقل کریں"
 msgid "Copied! Paste it into a terminal and run it."
 msgstr "نقل ہو گیا۔ اسے ٹرمینل میں چسپاں کر کے چلائیں۔"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:32
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:33
 msgid ""
 "No VA-API encoder for your graphics card. Install your distribution’s VA-API "
 "driver."
@@ -204,125 +204,126 @@ msgstr ""
 "آپ کے گرافکس کارڈ کے لیے کوئی VA-API اینکوڈر نہیں ہے۔ اپنی ڈسٹری بیوشن کا VA-"
 "API ڈرائیور نصب کریں۔"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:36
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:37
 msgid "Install the NVIDIA driver and the GStreamer nvcodec plugin."
 msgstr "NVIDIA ڈرائیور اور GStreamer nvcodec پلگ ان نصب کریں۔"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:39
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:40
 #, javascript-format
 msgid "The GStreamer VA-API plugin is missing. Install the %s package."
 msgstr "GStreamer VA-API پلگ ان موجود نہیں ہے۔ %s پیکیج نصب کریں۔"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:43
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:44
 msgid ""
 "The GStreamer VA-API plugin is missing. Install it from your distribution."
 msgstr ""
 "GStreamer VA-API پلگ ان موجود نہیں ہے۔ اسے اپنی ڈسٹری بیوشن سے نصب کریں۔"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:62
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:70
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:74
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:81
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:71
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:139
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:146
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:147
 msgid "Automatic"
 msgstr "خودکار"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
 msgid "Native"
 msgstr "اصل"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
 msgid "4K (2160p)"
 msgstr "4K (2160p)"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
 msgid "1440p"
 msgstr "1440p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
 msgid "1080p"
 msgstr "1080p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:68
 msgid "720p"
 msgstr "720p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:75
-msgid "Hardware only"
-msgstr "صرف ہارڈویئر"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:76
-msgid "Software only"
-msgstr "صرف سافٹ ویئر"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:77
-msgid "VA-API (Intel, AMD)"
-msgstr "VA-API (Intel، AMD)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:78
-msgid "NVENC (NVIDIA)"
-msgstr "NVENC (NVIDIA)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
-msgid "V4L2 (Arm boards)"
-msgstr "V4L2 (Arm بورڈ)"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:84
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:73
 msgid "Advanced"
 msgstr "اعلیٰ"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:90
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
 msgid "Stream quality"
 msgstr "اسٹریم کا معیار"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:91
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:80
 msgid "Applied the next time a cast is started"
 msgstr "اگلی بار کاسٹ شروع ہونے پر لاگو ہوگا"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:85
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:15
 msgid "Maximum resolution"
 msgstr "زیادہ سے زیادہ ریزولوشن"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:86
 msgid "Above 1080p needs a hardware encoder and a matching bitrate"
 msgstr "1080p سے اوپر ہارڈویئر اینکوڈر اور اس کے مطابق بٹ ریٹ درکار ہے"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
 msgid "Framerate"
 msgstr "فریم ریٹ"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
 msgid "Frames per second"
 msgstr "فریم فی سیکنڈ"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
 msgid "Video bitrate"
 msgstr "ویڈیو بٹ ریٹ"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:119
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
 msgid "kbit/s: about 4000 for 720p, 8000 for 1080p, 30000 for 4K"
 msgstr "kbit/s: 720p کے لیے تقریباً 4000، 1080p کے لیے 8000، 4K کے لیے 30000"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:129
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
 msgid "Audio bitrate"
 msgstr "آڈیو بٹ ریٹ"
 
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:140
+msgid "Hardware only"
+msgstr "صرف ہارڈویئر"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:141
+msgid "Software only"
+msgstr "صرف سافٹ ویئر"
+
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:142
+msgid "VA-API (Intel, AMD)"
+msgstr "VA-API (Intel، AMD)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+msgid "NVENC (NVIDIA)"
+msgstr "NVENC (NVIDIA)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:144
+msgid "V4L2 (Arm boards)"
+msgstr "V4L2 (Arm بورڈ)"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
 msgid "Encoding"
 msgstr "اینکوڈنگ"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:151
 msgid "Casting fails with a message when a forced choice cannot be used"
 msgstr ""
 "جب مقرر کردہ انتخاب استعمال نہ ہو سکے تو کاسٹ ایک پیغام کے ساتھ ناکام ہو "
 "جاتی ہے"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:148
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:156
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:46
 msgid "Video encoder"
 msgstr "وڈیو اینکوڈر"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:158
 msgid ""
 "Automatic prefers your graphics card; choose software if the picture breaks "
 "up"
@@ -330,74 +331,84 @@ msgstr ""
 "خودکار آپ کے گرافکس کارڈ کو ترجیح دیتا ہے؛ تصویر ٹوٹنے پر سافٹ ویئر منتخب "
 "کریں"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:161
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:56
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
+#, fuzzy
+msgid "Video codec"
+msgstr "وڈیو اینکوڈر"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
+msgid "Choose VP8 if the receiver freezes or displays a broken picture"
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
 msgid "Pixel format"
 msgstr "پکسل فارمیٹ"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:162
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:181
 msgid "Automatic suits every encoder; only change this to work around a driver"
 msgstr ""
 "خودکار ہر اینکوڈر کے لیے موزوں ہے؛ اسے صرف کسی ڈرائیور سے بچنے کے لیے بدلیں"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:191
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
 msgid "Hardware encoding is unavailable"
 msgstr "ہارڈویئر اینکوڈنگ دستیاب نہیں ہے"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:204
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:224
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:221
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:241
 msgid "Menu"
 msgstr "مینو"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:61
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:225
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:73
 msgid "Show cast details"
 msgstr "کاسٹ کی تفصیلات دکھائیں"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:209
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:62
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:226
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:74
 msgid "Show the transport and codecs under the active device while casting"
 msgstr "کاسٹ کرتے وقت فعال آلے کے نیچے ٹرانسپورٹ اور کوڈیکس دکھائیں"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Top bar"
 msgstr "اوپری پٹی"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Quick settings"
 msgstr "فوری ترتیبات"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:219
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:236
 msgid "General"
 msgstr "عمومی"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:228
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:70
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:245
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:82
 msgid "Indicator location"
 msgstr "آئیکن کا مقام"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:229
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:246
 msgid "Show the cast icon in the top bar, or in the quick settings menu"
 msgstr "کاسٹ آئیکن اوپری پٹی میں دکھائیں، یا فوری ترتیبات کے مینو میں"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:243
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:260
 msgid "About"
 msgstr "تعارف"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:254
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:271
 #, javascript-format
 msgid "Version %s"
 msgstr "ورژن %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:269
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:286
 msgid "Help"
 msgstr "مدد"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:270
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:287
 msgid "Common problems and their fixes"
 msgstr "عام مسائل اور ان کے حل"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:273
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:290
 msgid "Troubleshooting guide"
 msgstr "مسائل کے حل کی رہنمائی"
 
@@ -459,7 +470,14 @@ msgstr ""
 "”v4l2“ (Arm بورڈ) ایک ہارڈویئر انٹرفیس مقرر کرتے ہیں؛ انتخاب پورا نہ ہو سکے "
 "تو کاسٹ ایک پیغام کے ساتھ ناکام ہو جاتی ہے۔"
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:57
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid ""
+"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
+"available on this computer and lets the receiver choose. Force VP8 when a "
+"receiver freezes or displays a broken picture with another codec."
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""
 "The raw video format handed to the encoder. \"auto\" offers both and lets "
 "negotiation pick whichever the chosen encoder accepts. Forcing a format "
@@ -471,7 +489,7 @@ msgstr ""
 "مجبور کرنا کاسٹنگ کو انہی اینکوڈرز تک محدود کر دیتا ہے جو اسے قبول کرتے ہیں، "
 "جس کا زیادہ تر سسٹمز پر مطلب اینکوڈر کی قسم بھی مجبور کرنا ہے۔"
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:71
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:83
 msgid ""
 "Where to show the cast indicator: the top-bar tray, or the quick settings "
 "menu."

--- a/extension/gnome-shell-cast@oxygenws.com/po/zh_CN.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/zh_CN.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-09-02 21:09+0200\n"
+"POT-Creation-Date: 2026-09-03 08:40+0200\n"
 "PO-Revision-Date: 2026-08-14 10:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: Simplified Chinese <https://github.com/omid/gnome-shell-"
@@ -321,13 +321,13 @@ msgstr "自动会优先使用显卡；若画面破碎请选择软件"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
-#, fuzzy
 msgid "Video codec"
-msgstr "视频编码器"
+msgstr "视频编解码器"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
-msgid "Choose VP8 if the receiver freezes or displays a broken picture"
-msgstr ""
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid "Automatic lets the receiver choose from the available codecs"
+msgstr "自动模式允许接收器从可用的编解码器中选择"
 
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
@@ -450,13 +450,6 @@ msgstr ""
 "件。当显卡驱动产生破碎或卡顿的画面时请选择软件。“vaapi”（Intel、"
 "AMD）、“nvenc”（NVIDIA）和“v4l2”（Arm 开发板）会固定使用某一种硬件接口；若无"
 "法满足该选择，投屏将失败并给出提示。"
-
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
-msgid ""
-"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
-"available on this computer and lets the receiver choose. Force VP8 when a "
-"receiver freezes or displays a broken picture with another codec."
-msgstr ""
 
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""

--- a/extension/gnome-shell-cast@oxygenws.com/po/zh_CN.po
+++ b/extension/gnome-shell-cast@oxygenws.com/po/zh_CN.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Cast 3\n"
 "Report-Msgid-Bugs-To: https://github.com/omid/gnome-shell-cast/issues\n"
-"POT-Creation-Date: 2026-08-21 21:03+0200\n"
+"POT-Creation-Date: 2026-09-02 21:09+0200\n"
 "PO-Revision-Date: 2026-08-14 10:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: Simplified Chinese <https://github.com/omid/gnome-shell-"
@@ -73,20 +73,20 @@ msgstr "编码器：%s（软件）"
 msgid "Receiver supports: %s"
 msgstr "接收端支持：%s"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:446
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:447
 msgid "The cast failed."
 msgstr "投屏失败。"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:453
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
 #, javascript-format
 msgid "The device ended the session (%s)."
 msgstr "设备已结束会话（%s）。"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:454
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:455
 msgid "The device ended the session."
 msgstr "设备已结束会话。"
 
-#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:502
+#: extension/gnome-shell-cast@oxygenws.com/lib/castMenu.js:503
 #: extension/gnome-shell-cast@oxygenws.com/lib/indicator.js:22
 #: extension/gnome-shell-cast@oxygenws.com/lib/quickIndicator.js:62
 msgid "GNOME Shell Cast"
@@ -138,7 +138,7 @@ msgid "Close"
 msgstr "关闭"
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/errorDialog.js:40
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:266
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:283
 msgid "Report an issue"
 msgstr "报告问题"
 
@@ -178,7 +178,7 @@ msgid "Copy the command, then paste it into a terminal and run it."
 msgstr "复制命令，然后粘贴到终端中运行。"
 
 #: extension/gnome-shell-cast@oxygenws.com/lib/setupDialog.js:43
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:265
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:282
 msgid "Homepage"
 msgstr "主页"
 
@@ -190,201 +190,212 @@ msgstr "复制命令"
 msgid "Copied! Paste it into a terminal and run it."
 msgstr "已复制。请粘贴到终端中运行。"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:32
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:33
 msgid ""
 "No VA-API encoder for your graphics card. Install your distribution’s VA-API "
 "driver."
 msgstr ""
 "您的显卡没有可用的 VA-API 编码器。请安装您的发行版提供的 VA-API 驱动程序。"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:36
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:37
 msgid "Install the NVIDIA driver and the GStreamer nvcodec plugin."
 msgstr "请安装 NVIDIA 驱动程序和 GStreamer nvcodec 插件。"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:39
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:40
 #, javascript-format
 msgid "The GStreamer VA-API plugin is missing. Install the %s package."
 msgstr "缺少 GStreamer VA-API 插件。请安装 %s 软件包。"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:43
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:44
 msgid ""
 "The GStreamer VA-API plugin is missing. Install it from your distribution."
 msgstr "缺少 GStreamer VA-API 插件。请通过您的发行版安装它。"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:62
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:70
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:74
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:81
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:71
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:139
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:146
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:147
 msgid "Automatic"
 msgstr "自动"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:63
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
 msgid "Native"
 msgstr "原生"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:64
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
 msgid "4K (2160p)"
 msgstr "4K (2160p)"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:65
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
 msgid "1440p"
 msgstr "1440p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:66
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
 msgid "1080p"
 msgstr "1080p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:67
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:68
 msgid "720p"
 msgstr "720p"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:75
-msgid "Hardware only"
-msgstr "仅硬件"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:76
-msgid "Software only"
-msgstr "仅软件"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:77
-msgid "VA-API (Intel, AMD)"
-msgstr "VA-API（Intel、AMD）"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:78
-msgid "NVENC (NVIDIA)"
-msgstr "NVENC（NVIDIA）"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
-msgid "V4L2 (Arm boards)"
-msgstr "V4L2（Arm 开发板）"
-
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:84
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:73
 msgid "Advanced"
 msgstr "高级"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:90
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:79
 msgid "Stream quality"
 msgstr "视频流质量"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:91
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:80
 msgid "Applied the next time a cast is started"
 msgstr "将在下次开始投屏时生效"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:85
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:15
 msgid "Maximum resolution"
 msgstr "最大分辨率"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:86
 msgid "Above 1080p needs a hardware encoder and a matching bitrate"
 msgstr "高于 1080p 需要硬件编码器和相应的比特率"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:96
 msgid "Framerate"
 msgstr "帧率"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:97
 msgid "Frames per second"
 msgstr "每秒帧数"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:107
 msgid "Video bitrate"
 msgstr "视频比特率"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:119
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:108
 msgid "kbit/s: about 4000 for 720p, 8000 for 1080p, 30000 for 4K"
 msgstr "kbit/s：720p 约 4000，1080p 约 8000，4K 约 30000"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:129
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:118
 msgid "Audio bitrate"
 msgstr "音频比特率"
 
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:140
+msgid "Hardware only"
+msgstr "仅硬件"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:141
+msgid "Software only"
+msgstr "仅软件"
+
 #: extension/gnome-shell-cast@oxygenws.com/prefs.js:142
+msgid "VA-API (Intel, AMD)"
+msgstr "VA-API（Intel、AMD）"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+msgid "NVENC (NVIDIA)"
+msgstr "NVENC（NVIDIA）"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:144
+msgid "V4L2 (Arm boards)"
+msgstr "V4L2（Arm 开发板）"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
 msgid "Encoding"
 msgstr "编码"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:143
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:151
 msgid "Casting fails with a message when a forced choice cannot be used"
 msgstr "当强制选择无法使用时，投屏会失败并给出提示"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:148
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:156
 #: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:46
 msgid "Video encoder"
 msgstr "视频编码器"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:150
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:158
 msgid ""
 "Automatic prefers your graphics card; choose software if the picture breaks "
 "up"
 msgstr "自动会优先使用显卡；若画面破碎请选择软件"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:161
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:56
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:169
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:58
+#, fuzzy
+msgid "Video codec"
+msgstr "视频编码器"
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:170
+msgid "Choose VP8 if the receiver freezes or displays a broken picture"
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:180
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:68
 msgid "Pixel format"
 msgstr "像素格式"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:162
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:181
 msgid "Automatic suits every encoder; only change this to work around a driver"
 msgstr "自动适用于所有编码器；仅在需要绕开驱动问题时才更改"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:191
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
 msgid "Hardware encoding is unavailable"
 msgstr "硬件编码不可用"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:204
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:224
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:221
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:241
 msgid "Menu"
 msgstr "菜单"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:208
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:61
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:225
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:73
 msgid "Show cast details"
 msgstr "显示投屏详细信息"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:209
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:62
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:226
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:74
 msgid "Show the transport and codecs under the active device while casting"
 msgstr "投屏时在活动设备下方显示传输方式和编解码器"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Top bar"
 msgstr "顶栏"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:216
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:233
 msgid "Quick settings"
 msgstr "快速设置"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:219
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:236
 msgid "General"
 msgstr "常规"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:228
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:70
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:245
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:82
 msgid "Indicator location"
 msgstr "图标位置"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:229
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:246
 msgid "Show the cast icon in the top bar, or in the quick settings menu"
 msgstr "在顶栏或快速设置菜单中显示投屏图标"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:243
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:260
 msgid "About"
 msgstr "关于"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:254
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:271
 #, javascript-format
 msgid "Version %s"
 msgstr "版本 %s"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:269
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:286
 msgid "Help"
 msgstr "帮助"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:270
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:287
 msgid "Common problems and their fixes"
 msgstr "常见问题及其解决方法"
 
-#: extension/gnome-shell-cast@oxygenws.com/prefs.js:273
+#: extension/gnome-shell-cast@oxygenws.com/prefs.js:290
 msgid "Troubleshooting guide"
 msgstr "故障排除指南"
 
@@ -440,7 +451,14 @@ msgstr ""
 "AMD）、“nvenc”（NVIDIA）和“v4l2”（Arm 开发板）会固定使用某一种硬件接口；若无"
 "法满足该选择，投屏将失败并给出提示。"
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:57
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:59
+msgid ""
+"Which codec to offer for Cast Streaming. \"auto\" offers every codec "
+"available on this computer and lets the receiver choose. Force VP8 when a "
+"receiver freezes or displays a broken picture with another codec."
+msgstr ""
+
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:69
 msgid ""
 "The raw video format handed to the encoder. \"auto\" offers both and lets "
 "negotiation pick whichever the chosen encoder accepts. Forcing a format "
@@ -451,7 +469,7 @@ msgstr ""
 "一种。强制某种格式会将投放限制在接受该格式的编码器上，在大多数系统上这也等于"
 "强制了编码器类型。"
 
-#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:71
+#: extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml:83
 msgid ""
 "Where to show the cast indicator: the top-bar tray, or the quick settings "
 "menu."

--- a/extension/gnome-shell-cast@oxygenws.com/prefs.js
+++ b/extension/gnome-shell-cast@oxygenws.com/prefs.js
@@ -19,6 +19,7 @@ const BITRATE_VALUES = [0, 2000, 4000, 8000, 16000, 30000];
 const AUDIO_BITRATE_VALUES = [0, 64, 96, 128, 192, 256];
 const LOCATION_VALUES = ['tray', 'quick-settings'];
 const ENCODER_VALUES = ['auto', 'hardware', 'software', 'vaapi', 'nvenc', 'v4l2'];
+const CODEC_VALUES = ['auto', 'vp8', 'vp9', 'h264', 'av1'];
 const FORMAT_VALUES = ['auto', 'nv12', 'i420'];
 
 // The daemon decides which piece is missing; this only phrases it, because the
@@ -142,6 +143,7 @@ export default class GnomeShellCastPreferences extends ExtensionPreferences {
             _('NVENC (NVIDIA)'),
             _('V4L2 (Arm boards)'),
         ];
+        const codecLabels = [_('Automatic'), 'VP8', 'VP9', 'H.264', 'AV1'];
         const formatLabels = [_('Automatic'), 'NV12', 'I420'];
 
         const encodingGroup = new Adw.PreferencesGroup({
@@ -162,6 +164,17 @@ export default class GnomeShellCastPreferences extends ExtensionPreferences {
             settings.set_string('video-encoder', ENCODER_VALUES[row.selected]);
         });
         encodingGroup.add(encoderRow);
+
+        const codecRow = new Adw.ComboRow({
+            title: _('Video codec'),
+            subtitle: _('Choose VP8 if the receiver freezes or displays a broken picture'),
+            model: new Gtk.StringList({ strings: codecLabels }),
+            selected: Math.max(0, CODEC_VALUES.indexOf(settings.get_string('video-codec'))),
+        });
+        codecRow.connect('notify::selected', (row) => {
+            settings.set_string('video-codec', CODEC_VALUES[row.selected]);
+        });
+        encodingGroup.add(codecRow);
 
         const formatRow = new Adw.ComboRow({
             title: _('Pixel format'),

--- a/extension/gnome-shell-cast@oxygenws.com/prefs.js
+++ b/extension/gnome-shell-cast@oxygenws.com/prefs.js
@@ -167,7 +167,7 @@ export default class GnomeShellCastPreferences extends ExtensionPreferences {
 
         const codecRow = new Adw.ComboRow({
             title: _('Video codec'),
-            subtitle: _('Choose VP8 if the receiver freezes or displays a broken picture'),
+            subtitle: _('Automatic lets the receiver choose from the available codecs'),
             model: new Gtk.StringList({ strings: codecLabels }),
             selected: Math.max(0, CODEC_VALUES.indexOf(settings.get_string('video-codec'))),
         });

--- a/extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml
+++ b/extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml
@@ -56,7 +56,7 @@
       </choices>
       <default>'auto'</default>
       <summary>Video codec</summary>
-      <description>Which codec to offer for Cast Streaming. "auto" offers every codec available on this computer and lets the receiver choose. Force VP8 when a receiver freezes or displays a broken picture with another codec.</description>
+      <description>Automatic lets the receiver choose from the available codecs</description>
     </key>
     <key name="video-format" type="s">
       <choices>

--- a/extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml
+++ b/extension/gnome-shell-cast@oxygenws.com/schemas/org.gnome.shell.extensions.gnome-shell-cast.gschema.xml
@@ -46,6 +46,18 @@
       <summary>Video encoder</summary>
       <description>Which encoder to use. "auto" prefers hardware (VA-API, NVENC, V4L2) and falls back to software. Choose software when a graphics driver produces a broken or stuttering picture. "vaapi" (Intel, AMD), "nvenc" (NVIDIA) and "v4l2" (Arm boards) pin one hardware API. Casting fails with a message if the choice cannot be met.</description>
     </key>
+    <key name="video-codec" type="s">
+      <choices>
+        <choice value="auto"/>
+        <choice value="vp8"/>
+        <choice value="vp9"/>
+        <choice value="h264"/>
+        <choice value="av1"/>
+      </choices>
+      <default>'auto'</default>
+      <summary>Video codec</summary>
+      <description>Which codec to offer for Cast Streaming. "auto" offers every codec available on this computer and lets the receiver choose. Force VP8 when a receiver freezes or displays a broken picture with another codec.</description>
+    </key>
     <key name="video-format" type="s">
       <choices>
         <choice value="auto"/>

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788179007,
+        "narHash": "sha256-hn1oU2rue2SYK8dAr8+WNZWtbsz1S2W5mnHlSEuh3bo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "34ab99075ac4f7e40cf037eef32cb1c360bb85e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}


### PR DESCRIPTION
## Summary

- send RTCP sender reports correctly from unconnected RTP sockets
- accept legacy Cast device certificates while still verifying the expected device identity
- pace RTP packets in bounded 10 ms bursts to avoid overrunning receiver buffers
- add an Automatic/VP8/VP9/H.264/AV1 codec preference, allowing incompatible receivers to be pinned to VP8 without device-specific code
- add `flake.lock` so Nix builds use a reproducible dependency set

## Validation

- `cargo test` (96 passed)
- `cargo clippy --all-targets -- -D warnings`
- Prettier and ESLint
- strict GSettings schema validation
- translation extraction, merge, and compilation
- `nix flake check --no-build`
- Nix production build
- live 1080p30 mirroring with the new VP8 preference for over 100 seconds on an LG OLED55C21LA; the receiver accepted only VP8 and kept returning RTCP feedback

## Nix dependency lock

The lock file pins `nixpkgs` to `34ab99075ac4f7e40cf037eef32cb1c360bb85e9` (nixos-unstable). It makes the Rust, GStreamer, and other build inputs reproducible; it does not contain receiver-specific configuration.

## Notes

The five commits are kept separate by concern. Automatic codec selection preserves the existing behaviour. A forced codec is an explicit compatibility escape hatch; per-device profiles can build on this preference later.
